### PR TITLE
Fix: manage stake form improvements and minor fixes

### DIFF
--- a/apps/staking/app/mystakes/modules/NoticeModule.tsx
+++ b/apps/staking/app/mystakes/modules/NoticeModule.tsx
@@ -3,6 +3,7 @@
 import { URL } from '@/lib/constants';
 import { externalLink } from '@/lib/locale-defaults';
 import { Module, ModuleHeader, ModuleText } from '@session/ui/components/Module';
+import Typography from '@session/ui/components/Typography';
 import { useTranslations } from 'next-intl';
 
 export default function NoticeModule() {
@@ -10,14 +11,14 @@ export default function NoticeModule() {
 
   return (
     <Module size="lg" className="flex flex-grow">
-      <ModuleHeader>
+      <ModuleHeader className="overflow-auto">
         <ModuleText>{dict('title')}</ModuleText>
-        <br />
-        <br />
-        {dict.rich('description', {
-          link: externalLink(URL.DOCS),
-          'bridge-link': externalLink('https://getsession.org/'),
-        })}
+        <Typography variant="p" className="mt-6">
+          {dict.rich('description', {
+            link: externalLink(URL.DOCS),
+            'bridge-link': externalLink('https://getsession.org/'),
+          })}
+        </Typography>
       </ModuleHeader>
     </Module>
   );

--- a/apps/staking/app/register/[nodeId]/multi/OperatorFeeTab.tsx
+++ b/apps/staking/app/register/[nodeId]/multi/OperatorFeeTab.tsx
@@ -4,7 +4,7 @@ import {
   useRegistrationWizard,
 } from '@/app/register/[nodeId]/Registration';
 import { REG_MODE, REG_TAB } from '@/app/register/[nodeId]/types';
-import OperatorFeeField from '@/components/Form/OperatorFeeField';
+import { OperatorFeeField } from '@/components/Form/OperatorFeeField';
 import { SESSION_NODE } from '@/lib/constants';
 import { ButtonDataTestId, InputDataTestId } from '@/testing/data-test-ids';
 import { Form, FormField } from '@session/ui/components/ui/form';

--- a/apps/staking/app/register/[nodeId]/multi/ReserveSlotsInputTab.tsx
+++ b/apps/staking/app/register/[nodeId]/multi/ReserveSlotsInputTab.tsx
@@ -4,12 +4,14 @@ import {
   useRegistrationWizard,
 } from '@/app/register/[nodeId]/Registration';
 import { REG_MODE, REG_TAB } from '@/app/register/[nodeId]/types';
-import EthereumAddressField, {
+import {
+  EthereumAddressField,
   getEthereumAddressFormFieldSchema,
 } from '@/components/Form/EthereumAddressField';
-import StakeAmountField, {
-  getStakeAmountFormFieldSchema,
+import {
   type GetStakeAmountFormFieldSchemaArgs,
+  StakeAmountField,
+  getStakeAmountFormFieldSchema,
 } from '@/components/Form/StakeAmountField';
 import { ReservedStakesTable } from '@/components/ReservedStakesTable';
 import type { ReservedContributorStruct } from '@/hooks/useCreateOpenNodeRegistration';

--- a/apps/staking/app/register/[nodeId]/multi/RewardsAddressInputMultiTab.tsx
+++ b/apps/staking/app/register/[nodeId]/multi/RewardsAddressInputMultiTab.tsx
@@ -4,7 +4,7 @@ import {
   useRegistrationWizard,
 } from '@/app/register/[nodeId]/Registration';
 import { REG_MODE, REG_TAB } from '@/app/register/[nodeId]/types';
-import EthereumAddressField from '@/components/Form/EthereumAddressField';
+import { EthereumAddressField } from '@/components/Form/EthereumAddressField';
 import { ButtonDataTestId, InputDataTestId } from '@/testing/data-test-ids';
 import { Form, FormField } from '@session/ui/components/ui/form';
 import { Button } from '@session/ui/ui/button';

--- a/apps/staking/app/register/[nodeId]/multi/StakeAmountTab.tsx
+++ b/apps/staking/app/register/[nodeId]/multi/StakeAmountTab.tsx
@@ -3,7 +3,7 @@ import {
   useRegistrationWizard,
 } from '@/app/register/[nodeId]/Registration';
 import { REG_MODE, REG_TAB } from '@/app/register/[nodeId]/types';
-import StakeAmountField from '@/components/Form/StakeAmountField';
+import { StakeAmountField } from '@/components/Form/StakeAmountField';
 import {
   SESSION_NODE_FULL_STAKE_AMOUNT,
   SESSION_NODE_MIN_STAKE_MULTI_OPERATOR,

--- a/apps/staking/app/register/[nodeId]/multi/SubmitMultiTab.tsx
+++ b/apps/staking/app/register/[nodeId]/multi/SubmitMultiTab.tsx
@@ -339,7 +339,7 @@ export function SubmitMultiTab() {
               data-testid={ButtonDataTestId.Registration_Submit_Multi_Edit_Reserve_Slots}
               tab={REG_TAB.RESERVE_SLOTS_INPUT}
               disabled={isReservedSlotsDisabled}
-              disabledReason={dictReservedSlotsTab('buttonReserve.disabledTooltip')}
+              disabledReason={dictReservedSlotsTab.rich('buttonReserve.disabledTooltip')}
               onClick={() => {
                 formMulti.setValue('reservedContributors', [
                   {

--- a/apps/staking/app/register/[nodeId]/solo/RewardsAddressInputSoloTab.tsx
+++ b/apps/staking/app/register/[nodeId]/solo/RewardsAddressInputSoloTab.tsx
@@ -1,6 +1,6 @@
 import { useRegistrationWizard } from '@/app/register/[nodeId]/Registration';
 import { REG_TAB } from '@/app/register/[nodeId]/types';
-import EthereumAddressField from '@/components/Form/EthereumAddressField';
+import { EthereumAddressField } from '@/components/Form/EthereumAddressField';
 import { ButtonDataTestId, InputDataTestId } from '@/testing/data-test-ids';
 import { Form, FormField } from '@session/ui/components/ui/form';
 import { Button } from '@session/ui/ui/button';

--- a/apps/staking/app/stake/[address]/ManageStakeContribution.tsx
+++ b/apps/staking/app/stake/[address]/ManageStakeContribution.tsx
@@ -5,8 +5,8 @@ import { SubmitContributeFunds } from '@/app/stake/[address]/SubmitContributeFun
 import { SubmitRemoveFunds } from '@/app/stake/[address]/SubmitRemoveFunds';
 import { SubmitRemoveFundsVesting } from '@/app/stake/[address]/SubmitRemoveFundsVesting';
 import { ActionModuleRow } from '@/components/ActionModule';
-import EthereumAddressField from '@/components/Form/EthereumAddressField';
-import StakeAmountField from '@/components/Form/StakeAmountField';
+import { EthereumAddressField } from '@/components/Form/EthereumAddressField';
+import { StakeAmountField } from '@/components/Form/StakeAmountField';
 import { WizardSectionDescription } from '@/components/Wizard';
 import { useBannedRewardsAddresses } from '@/hooks/useBannedRewardsAddresses';
 import type { UseContributeStakeToOpenNodeParams } from '@/hooks/useContributeStakeToOpenNode';
@@ -40,7 +40,7 @@ import { safeTrySync } from '@session/util-js/try';
 import { useBlockNumber } from '@session/wallet/hooks/useBlockNumber';
 import { useWallet } from '@session/wallet/hooks/useWallet';
 import { useTranslations } from 'next-intl';
-import { type Dispatch, type SetStateAction, useMemo, useState } from 'react';
+import { type Dispatch, type Ref, type SetStateAction, useMemo, useState } from 'react';
 import { usePreferences } from 'usepref';
 import { type Address, isAddress } from 'viem';
 import { SubmitContributeFundsVesting } from './SubmitContributeFundsVesting';
@@ -97,11 +97,15 @@ export function ManageStakeContribution({
   isSubmitting,
   setIsSubmitting,
   refetch,
+  stakeAmountRef,
+  rewardsAddressRef,
 }: {
   contract: ContributionContract;
   isSubmitting: boolean;
   setIsSubmitting: Dispatch<SetStateAction<boolean>>;
   refetch: () => void;
+  stakeAmountRef: Ref<HTMLInputElement>;
+  rewardsAddressRef: Ref<HTMLInputElement>;
 }) {
   const { getItem } = usePreferences();
   const [acceptedTopUpNotice, setAcceptedTopUpNotice] = useState<boolean>(
@@ -316,6 +320,7 @@ export function ManageStakeContribution({
             name="stakeAmount"
             render={({ field }) => (
               <StakeAmountField
+                ref={stakeAmountRef}
                 minStake={minStake}
                 maxStake={maxStake}
                 watchedStakeAmount={form.watch('stakeAmount')}
@@ -340,6 +345,7 @@ export function ManageStakeContribution({
             name="rewardsAddress"
             render={({ field }) => (
               <EthereumAddressField
+                ref={rewardsAddressRef}
                 // @ts-expect-error -- TODO: type this
                 field={field}
                 label={dictionaryShared('rewardsAddress')}

--- a/apps/staking/app/stake/[address]/NewStake.tsx
+++ b/apps/staking/app/stake/[address]/NewStake.tsx
@@ -6,13 +6,15 @@ import { SubmitContributeFunds } from '@/app/stake/[address]/SubmitContributeFun
 import { SubmitContributeFundsVesting } from '@/app/stake/[address]/SubmitContributeFundsVesting';
 import { ActionModuleRow } from '@/components/ActionModule';
 import type { ErrorBoxProps } from '@/components/Error/ErrorBox';
-import EthereumAddressField, {
-  getEthereumAddressFormFieldSchema,
+import {
+  EthereumAddressField,
   type GetEthereumAddressFormFieldSchemaArgs,
+  getEthereumAddressFormFieldSchema,
 } from '@/components/Form/EthereumAddressField';
-import StakeAmountField, {
-  getStakeAmountFormFieldSchema,
+import {
   type GetStakeAmountFormFieldSchemaArgs,
+  StakeAmountField,
+  getStakeAmountFormFieldSchema,
 } from '@/components/Form/StakeAmountField';
 import { useBannedRewardsAddresses } from '@/hooks/useBannedRewardsAddresses';
 import type { UseContributeStakeToOpenNodeParams } from '@/hooks/useContributeStakeToOpenNode';

--- a/apps/staking/app/stake/[address]/StakeInfo.tsx
+++ b/apps/staking/app/stake/[address]/StakeInfo.tsx
@@ -17,7 +17,7 @@ import { Tooltip } from '@session/ui/ui/tooltip';
 import { bigIntMax } from '@session/util-crypto/maths';
 import { areHexesEqual } from '@session/util-crypto/string';
 import { useTranslations } from 'next-intl';
-import type { ReactNode } from 'react';
+import { type ReactNode, forwardRef } from 'react';
 import { type Address, isAddress } from 'viem';
 
 export function getReservedSlots(contract: ContributionContract): Array<ReservedContributorStruct> {
@@ -96,198 +96,200 @@ export type StakeInfoProps = {
   children?: ReactNode;
 };
 
-export function StakeInfo({
-  contract,
-  totalStaked,
-  editableFields,
-  isSubmitting,
-  children,
-}: StakeInfoProps) {
-  const address = useCurrentActor();
+export const StakeInfo = forwardRef<HTMLDivElement, StakeInfoProps>(
+  ({ contract, totalStaked, editableFields, isSubmitting, children, ...props }, ref) => {
+    const address = useCurrentActor();
 
-  const dictionaryRegistrationShared = useTranslations('actionModules.registration.shared');
-  const dictShared = useTranslations('actionModules.shared');
-  const sessionNodeDictionary = useTranslations('sessionNodes.general');
-  const actionModuleDictionary = useTranslations('actionModules');
-  const dictGeneral = useTranslations('general');
+    const dictionaryRegistrationShared = useTranslations('actionModules.registration.shared');
+    const dictShared = useTranslations('actionModules.shared');
+    const sessionNodeDictionary = useTranslations('sessionNodes.general');
+    const actionModuleDictionary = useTranslations('actionModules');
+    const dictGeneral = useTranslations('general');
 
-  const isOperator = areHexesEqual(contract.operator_address, address);
-  const contributor = contract.contributors.find(
-    ({ address: contributorAddress, amount }) =>
-      areHexesEqual(contributorAddress, address) && amount > 0n
-  );
-  const haveOtherContributorsContributed = contract.contributors.length > 1;
-  const isFinalized = contract.status === CONTRIBUTION_CONTRACT_STATUS.Finalized;
+    const isOperator = areHexesEqual(contract.operator_address, address);
+    const contributor = contract.contributors.find(
+      ({ address: contributorAddress, amount }) =>
+        areHexesEqual(contributorAddress, address) && amount > 0n
+    );
+    const haveOtherContributorsContributed = contract.contributors.length > 1;
+    const isFinalized = contract.status === CONTRIBUTION_CONTRACT_STATUS.Finalized;
 
-  const reservedContributors = getReservedSlots(contract);
-  const hasReservedContributors = reservedContributors.length > 1;
+    const reservedContributors = getReservedSlots(contract);
+    const hasReservedContributors = reservedContributors.length > 1;
 
-  return (
-    <div className="flex w-full flex-col gap-3.5">
-      <ActionModuleRow
-        label={actionModuleDictionary('node.contributors')}
-        tooltip={actionModuleDictionary('node.contributorsTooltip')}
-      >
-        <span className="flex flex-row flex-wrap items-center gap-2 align-middle">
-          <NodeContributorList contributors={contract.contributors} forceExpand showEmptySlots />
-        </span>
-      </ActionModuleRow>
-      {contributor ? (
+    return (
+      <div className="flex w-full flex-col gap-3.5" {...props} ref={ref}>
         <ActionModuleRow
-          label={dictShared('yourStake')}
-          tooltip={dictShared('yourStakeDescription')}
+          label={actionModuleDictionary('node.contributors')}
+          tooltip={actionModuleDictionary('node.contributorsTooltip')}
         >
-          {formatSENTBigInt(contributor.amount)}
-          <EditButton
-            aria-label={dictShared('buttonEditField.aria', { field: dictShared('yourStake') })}
-            data-testid={ButtonDataTestId.Stake_Edit_Stake_Amount}
-            disabled={
-              isSubmitting ||
-              isFinalized ||
-              editableFields?.stakeAmount?.disabled ||
-              !editableFields?.stakeAmount?.editOnClick
-            }
-            onClick={editableFields?.stakeAmount?.editOnClick}
-          />
+          <span className="flex flex-row flex-wrap items-center gap-2 align-middle">
+            <NodeContributorList contributors={contract.contributors} forceExpand showEmptySlots />
+          </span>
         </ActionModuleRow>
-      ) : null}
-      <ActionModuleRow
-        label={dictShared('totalStaked')}
-        tooltip={dictShared('totalStakedDescription')}
-      >
-        {`${formatSENTBigInt(totalStaked ?? getTotalStaked(contract.contributors), TOKEN.DECIMALS, true)} / ${formatSENTBigInt(SESSION_NODE_FULL_STAKE_AMOUNT)}`}
-      </ActionModuleRow>
-      <ActionModuleRow
-        label={sessionNodeDictionary('publicKeyShort')}
-        tooltip={sessionNodeDictionary('publicKeyDescription')}
-      >
-        <PubKey
-          pubKey={contract.service_node_pubkey}
-          force="collapse"
-          alwaysShowCopyButton
-          leadingChars={8}
-          trailingChars={4}
-        />
-      </ActionModuleRow>
-      <ActionModuleRow
-        label={sessionNodeDictionary('blsKey')}
-        tooltip={sessionNodeDictionary('blsKeyDescription')}
-      >
-        <PubKey
-          pubKey={contract.pubkey_bls ?? dictGeneral('notFound')}
-          force="collapse"
-          alwaysShowCopyButton
-          leadingChars={8}
-          trailingChars={4}
-        />
-      </ActionModuleRow>
-      <ActionModuleRow
-        label={dictShared('autoActivate')}
-        tooltip={dictShared('autoActivateDescription')}
-      >
-        <span className="font-semibold">
-          {dictShared(!contract.manual_finalize ? 'enabled' : 'disabled')}
-        </span>
-        {isOperator ? (
-          <Tooltip tooltipContent="Editing this field is not yet supported">
+        {contributor ? (
+          <ActionModuleRow
+            label={dictShared('yourStake')}
+            tooltip={dictShared('yourStakeDescription')}
+          >
+            {formatSENTBigInt(contributor.amount)}
             <EditButton
-              aria-label={dictShared('buttonEditField.aria', { field: dictShared('autoActivate') })}
-              data-testid={ButtonDataTestId.Stake_Edit_Auto_Activate}
+              aria-label={dictShared('buttonEditField.aria', { field: dictShared('yourStake') })}
+              data-testid={ButtonDataTestId.Stake_Edit_Stake_Amount}
               disabled={
-                // TODO: Implement auto activation field changing
-                true ||
                 isSubmitting ||
                 isFinalized ||
-                editableFields?.autoActivate?.disabled ||
-                !editableFields?.autoActivate?.editOnClick
+                editableFields?.stakeAmount?.disabled ||
+                !editableFields?.stakeAmount?.editOnClick
               }
-              onClick={editableFields?.autoActivate?.editOnClick}
+              onClick={editableFields?.stakeAmount?.editOnClick}
             />
-          </Tooltip>
+          </ActionModuleRow>
         ) : null}
-      </ActionModuleRow>
-      <ActionModuleRow
-        label={dictShared('operatorAddress')}
-        tooltip={dictShared('operatorAddressDescription')}
-      >
-        <PubKey
-          pubKey={contract.operator_address}
-          force="collapse"
-          alwaysShowCopyButton
-          leadingChars={8}
-          trailingChars={4}
-          className="font-semibold"
-        />
-      </ActionModuleRow>
-      <ActionModuleRow
-        label={dictShared('operatorFee')}
-        tooltip={dictShared('operatorFeeDescription')}
-      >
-        <span className="font-semibold">
-          {contract.fee !== null ? formatPercentage(contract.fee / 10000) : dictGeneral('notFound')}
-        </span>
-        {isOperator ? (
-          <Tooltip tooltipContent="Editing this field is not yet supported">
-            <EditButton
-              disabled={
-                // TODO: Implement operator fee field changing
-                true ||
-                haveOtherContributorsContributed ||
-                isSubmitting ||
-                isFinalized ||
-                editableFields?.operatorFee?.disabled ||
-                !editableFields?.operatorFee?.editOnClick
-              }
-              onClick={editableFields?.operatorFee?.editOnClick}
-              aria-label={dictShared('buttonEditField.aria', { field: dictShared('operatorFee') })}
-              data-testid={ButtonDataTestId.Stake_Edit_Operator_Fee}
-            />
-          </Tooltip>
-        ) : null}
-      </ActionModuleRow>
-      {contributor ? (
         <ActionModuleRow
-          label={dictShared('rewardsAddress')}
-          tooltip={dictShared('rewardsAddressDescription')}
+          label={dictShared('totalStaked')}
+          tooltip={dictShared('totalStakedDescription')}
+        >
+          {`${formatSENTBigInt(totalStaked ?? getTotalStaked(contract.contributors), TOKEN.DECIMALS, true)} / ${formatSENTBigInt(SESSION_NODE_FULL_STAKE_AMOUNT)}`}
+        </ActionModuleRow>
+        <ActionModuleRow
+          label={sessionNodeDictionary('publicKeyShort')}
+          tooltip={sessionNodeDictionary('publicKeyDescription')}
         >
           <PubKey
-            pubKey={contributor.beneficiary_address ?? contributor.address ?? dictGeneral('none')}
+            pubKey={contract.service_node_pubkey}
+            force="collapse"
+            alwaysShowCopyButton
+            leadingChars={8}
+            trailingChars={4}
+          />
+        </ActionModuleRow>
+        <ActionModuleRow
+          label={sessionNodeDictionary('blsKey')}
+          tooltip={sessionNodeDictionary('blsKeyDescription')}
+        >
+          <PubKey
+            pubKey={contract.pubkey_bls ?? dictGeneral('notFound')}
+            force="collapse"
+            alwaysShowCopyButton
+            leadingChars={8}
+            trailingChars={4}
+          />
+        </ActionModuleRow>
+        <ActionModuleRow
+          label={dictShared('autoActivate')}
+          tooltip={dictShared('autoActivateDescription')}
+        >
+          <span className="font-semibold">
+            {dictShared(!contract.manual_finalize ? 'enabled' : 'disabled')}
+          </span>
+          {isOperator ? (
+            <Tooltip tooltipContent="Editing this field is not yet supported">
+              <EditButton
+                aria-label={dictShared('buttonEditField.aria', {
+                  field: dictShared('autoActivate'),
+                })}
+                data-testid={ButtonDataTestId.Stake_Edit_Auto_Activate}
+                disabled={
+                  // TODO: Implement auto activation field changing
+                  true ||
+                  isSubmitting ||
+                  isFinalized ||
+                  editableFields?.autoActivate?.disabled ||
+                  !editableFields?.autoActivate?.editOnClick
+                }
+                onClick={editableFields?.autoActivate?.editOnClick}
+              />
+            </Tooltip>
+          ) : null}
+        </ActionModuleRow>
+        <ActionModuleRow
+          label={dictShared('operatorAddress')}
+          tooltip={dictShared('operatorAddressDescription')}
+        >
+          <PubKey
+            pubKey={contract.operator_address}
             force="collapse"
             alwaysShowCopyButton
             leadingChars={8}
             trailingChars={4}
             className="font-semibold"
           />
-          <EditButton
-            disabled={
-              isSubmitting ||
-              isFinalized ||
-              editableFields?.rewardsAddress?.disabled ||
-              !editableFields?.rewardsAddress?.editOnClick
-            }
-            onClick={editableFields?.rewardsAddress?.editOnClick}
-            aria-label={dictionaryRegistrationShared('buttonEditField.aria')}
-            data-testid={ButtonDataTestId.Stake_Edit_Rewards_Address}
-          />
         </ActionModuleRow>
-      ) : null}
-      <ActionModuleRow
-        label={dictShared('reserveSlots')}
-        tooltip={dictShared('reserveSlotsDescription')}
-        parentClassName={
-          hasReservedContributors ? 'flex flex-col gap-2 justify-start items-start w-full' : ''
-        }
-        containerClassName={hasReservedContributors ? 'w-full' : ''}
-        last={hasReservedContributors}
-      >
-        {/* reservedContributors length 1 means only the operator, so we treat it as no reserved slots*/}
-        {hasReservedContributors ? (
-          <ReservedStakesTable reservedStakes={reservedContributors} className="my-2 w-full" />
-        ) : (
-          <span className="font-semibold">{dictGeneral('none')}</span>
-        )}
-      </ActionModuleRow>
-      {children}
-    </div>
-  );
-}
+        <ActionModuleRow
+          label={dictShared('operatorFee')}
+          tooltip={dictShared('operatorFeeDescription')}
+        >
+          <span className="font-semibold">
+            {contract.fee !== null
+              ? formatPercentage(contract.fee / 10000)
+              : dictGeneral('notFound')}
+          </span>
+          {isOperator ? (
+            <Tooltip tooltipContent="Editing this field is not yet supported">
+              <EditButton
+                disabled={
+                  // TODO: Implement operator fee field changing
+                  true ||
+                  haveOtherContributorsContributed ||
+                  isSubmitting ||
+                  isFinalized ||
+                  editableFields?.operatorFee?.disabled ||
+                  !editableFields?.operatorFee?.editOnClick
+                }
+                onClick={editableFields?.operatorFee?.editOnClick}
+                aria-label={dictShared('buttonEditField.aria', {
+                  field: dictShared('operatorFee'),
+                })}
+                data-testid={ButtonDataTestId.Stake_Edit_Operator_Fee}
+              />
+            </Tooltip>
+          ) : null}
+        </ActionModuleRow>
+        {contributor ? (
+          <ActionModuleRow
+            label={dictShared('rewardsAddress')}
+            tooltip={dictShared('rewardsAddressDescription')}
+          >
+            <PubKey
+              pubKey={contributor.beneficiary_address ?? contributor.address ?? dictGeneral('none')}
+              force="collapse"
+              alwaysShowCopyButton
+              leadingChars={8}
+              trailingChars={4}
+              className="font-semibold"
+            />
+            <EditButton
+              disabled={
+                isSubmitting ||
+                isFinalized ||
+                editableFields?.rewardsAddress?.disabled ||
+                !editableFields?.rewardsAddress?.editOnClick
+              }
+              onClick={editableFields?.rewardsAddress?.editOnClick}
+              aria-label={dictionaryRegistrationShared('buttonEditField.aria')}
+              data-testid={ButtonDataTestId.Stake_Edit_Rewards_Address}
+            />
+          </ActionModuleRow>
+        ) : null}
+        <ActionModuleRow
+          label={dictShared('reserveSlots')}
+          tooltip={dictShared('reserveSlotsDescription')}
+          parentClassName={
+            hasReservedContributors ? 'flex flex-col gap-2 justify-start items-start w-full' : ''
+          }
+          containerClassName={hasReservedContributors ? 'w-full' : ''}
+          last={hasReservedContributors}
+        >
+          {/* reservedContributors length 1 means only the operator, so we treat it as no reserved slots*/}
+          {hasReservedContributors ? (
+            <ReservedStakesTable reservedStakes={reservedContributors} className="my-2 w-full" />
+          ) : (
+            <span className="font-semibold">{dictGeneral('none')}</span>
+          )}
+        </ActionModuleRow>
+        {children}
+      </div>
+    );
+  }
+);

--- a/apps/staking/components/Form/EthereumAddressField.tsx
+++ b/apps/staking/components/Form/EthereumAddressField.tsx
@@ -3,6 +3,7 @@ import type { InputDataTestId } from '@/testing/data-test-ids';
 import { FormControl, FormItem, FormLabel, FormMessage } from '@session/ui/ui/form';
 import { Input } from '@session/ui/ui/input';
 import { useTranslations } from 'next-intl';
+import { forwardRef } from 'react';
 import { isAddress } from 'viem';
 import { z } from 'zod';
 
@@ -52,31 +53,29 @@ export type EthereumAddressFieldProps = {
   dataTestId: InputDataTestId;
 };
 
-export default function EthereumAddressField({
-  disabled,
-  field,
-  label,
-  tooltip,
-  dataTestId,
-}: EthereumAddressFieldProps) {
-  return (
-    <FormItem>
-      {label ? (
-        <FormLabel className="flex flex-row gap-1">
-          {label}
-          {tooltip ? <ActionModuleTooltip>{tooltip}</ActionModuleTooltip> : null}
-        </FormLabel>
-      ) : null}
-      <FormControl>
-        <Input
-          disabled={disabled}
-          className="w-full rounded-lg border-[#668C83] border-[2px] border-opacity-80 px-2 py-3 text-lg shadow-md"
-          // @ts-expect-error -- TODO: type this
-          {...field}
-          data-testid={dataTestId}
-        />
-      </FormControl>
-      <FormMessage />
-    </FormItem>
-  );
-}
+export const EthereumAddressField = forwardRef<HTMLInputElement, EthereumAddressFieldProps>(
+  ({ disabled, field, label, tooltip, dataTestId, ...props }, ref) => {
+    return (
+      <FormItem>
+        {label ? (
+          <FormLabel className="flex flex-row gap-1">
+            {label}
+            {tooltip ? <ActionModuleTooltip>{tooltip}</ActionModuleTooltip> : null}
+          </FormLabel>
+        ) : null}
+        <FormControl>
+          <Input
+            disabled={disabled}
+            className="w-full rounded-lg border-[#668C83] border-[2px] border-opacity-80 px-2 py-3 text-lg shadow-md"
+            // @ts-expect-error -- TODO: type this
+            {...field}
+            ref={ref}
+            data-testid={dataTestId}
+            {...props}
+          />
+        </FormControl>
+        <FormMessage />
+      </FormItem>
+    );
+  }
+);

--- a/apps/staking/components/Form/OperatorFeeField.tsx
+++ b/apps/staking/components/Form/OperatorFeeField.tsx
@@ -13,6 +13,8 @@ export type GetOperatorFeeFormFieldSchemaArgs = {
   overMaxOperatorFeeMessage: string;
 };
 
+const operatorFeeRegex = /^[0-9]*[.,]?[0-9]*$/;
+
 export const getOperatorFeeFormFieldSchema = ({
   minOperatorFee,
   maxOperatorFee,
@@ -22,7 +24,7 @@ export const getOperatorFeeFormFieldSchema = ({
 }: GetOperatorFeeFormFieldSchemaArgs) => {
   return z
     .string()
-    .regex(/^[0-9]*[.,]?[0-9]*$/, { message: incorrectFormatMessage })
+    .regex(operatorFeeRegex, { message: incorrectFormatMessage })
     .refine(
       (v) => {
         const n = Number.parseFloat(v);
@@ -50,6 +52,9 @@ export type OperatorFeeFieldProps = {
   placeholder: string;
 };
 
+const operatorFeeFormattingRegex = /[^0-9.,]/g;
+const operatorFeeLeadingZerosRegex = /^0+/;
+
 export const OperatorFeeField = forwardRef<HTMLInputElement, OperatorFeeFieldProps>(
   ({ dataTestId, disabled, field, maxFee, placeholder, ...props }, ref) => {
     const decimalDelimiter = useDecimalDelimiter();
@@ -57,7 +62,7 @@ export const OperatorFeeField = forwardRef<HTMLInputElement, OperatorFeeFieldPro
     const formatInputText = (value: string) => {
       if (value === '0') return '0';
       // Remove non-numeric characters and non-decimal delimiters
-      let formattedValue = value.replace(/[^0-9.,]/g, '');
+      let formattedValue = value.replace(operatorFeeFormattingRegex, '');
 
       // Remove thousands separators
       if (formattedValue.includes(thousandsSeparator)) {
@@ -66,7 +71,7 @@ export const OperatorFeeField = forwardRef<HTMLInputElement, OperatorFeeFieldPro
 
       // Remove any leading zeroes except when its `0.`
       if (formattedValue.startsWith('0') && !formattedValue.startsWith('0.')) {
-        formattedValue = formattedValue.replace(/^0+/, '');
+        formattedValue = formattedValue.replace(operatorFeeLeadingZerosRegex, '');
       }
 
       // Remove all but the first decimal delimiter

--- a/apps/staking/components/Form/OperatorFeeField.tsx
+++ b/apps/staking/components/Form/OperatorFeeField.tsx
@@ -2,6 +2,7 @@ import { useDecimalDelimiter } from '@/lib/locale-client';
 import type { InputDataTestId } from '@/testing/data-test-ids';
 import { FormControl, FormItem, FormMessage } from '@session/ui/ui/form';
 import { Input } from '@session/ui/ui/input';
+import { forwardRef } from 'react';
 import { z } from 'zod';
 
 export type GetOperatorFeeFormFieldSchemaArgs = {
@@ -49,68 +50,66 @@ export type OperatorFeeFieldProps = {
   placeholder: string;
 };
 
-export default function OperatorFeeField({
-  dataTestId,
-  disabled,
-  field,
-  maxFee,
-  placeholder,
-}: OperatorFeeFieldProps) {
-  const decimalDelimiter = useDecimalDelimiter();
-  const thousandsSeparator = decimalDelimiter === '.' ? ',' : '.';
-  const formatInputText = (value: string) => {
-    if (value === '0') return '0';
-    // Remove non-numeric characters and non-decimal delimiters
-    let formattedValue = value.replace(/[^0-9.,]/g, '');
+export const OperatorFeeField = forwardRef<HTMLInputElement, OperatorFeeFieldProps>(
+  ({ dataTestId, disabled, field, maxFee, placeholder, ...props }, ref) => {
+    const decimalDelimiter = useDecimalDelimiter();
+    const thousandsSeparator = decimalDelimiter === '.' ? ',' : '.';
+    const formatInputText = (value: string) => {
+      if (value === '0') return '0';
+      // Remove non-numeric characters and non-decimal delimiters
+      let formattedValue = value.replace(/[^0-9.,]/g, '');
 
-    // Remove thousands separators
-    if (formattedValue.includes(thousandsSeparator)) {
-      formattedValue = formattedValue.replaceAll(thousandsSeparator, '');
-    }
+      // Remove thousands separators
+      if (formattedValue.includes(thousandsSeparator)) {
+        formattedValue = formattedValue.replaceAll(thousandsSeparator, '');
+      }
 
-    // Remove any leading zeroes except when its `0.`
-    if (formattedValue.startsWith('0') && !formattedValue.startsWith('0.')) {
-      formattedValue = formattedValue.replace(/^0+/, '');
-    }
+      // Remove any leading zeroes except when its `0.`
+      if (formattedValue.startsWith('0') && !formattedValue.startsWith('0.')) {
+        formattedValue = formattedValue.replace(/^0+/, '');
+      }
 
-    // Remove all but the first decimal delimiter
-    if (formattedValue.includes(decimalDelimiter)) {
-      const [first, ...rest] = formattedValue.split(decimalDelimiter);
+      // Remove all but the first decimal delimiter
+      if (formattedValue.includes(decimalDelimiter)) {
+        const [first, ...rest] = formattedValue.split(decimalDelimiter);
 
-      const decimalValue = rest.join('').slice(0, 2);
-      formattedValue = `${first}${decimalDelimiter}${decimalValue}`;
-      // If the value is greater than the full stake, return the full stake
-    }
+        const decimalValue = rest.join('').slice(0, 2);
+        formattedValue = `${first}${decimalDelimiter}${decimalValue}`;
+        // If the value is greater than the full stake, return the full stake
+      }
 
-    if (Number.parseFloat(formattedValue) > maxFee) {
-      return maxFee.toString();
-    }
+      if (Number.parseFloat(formattedValue) > maxFee) {
+        return maxFee.toString();
+      }
 
-    return formattedValue;
-  };
+      return formattedValue;
+    };
 
-  return (
-    <FormItem className="-my-1 flex flex-col">
-      <div className="flex flex-row items-center gap-1 align-middle">
-        <FormControl>
-          <Input
-            placeholder={placeholder}
-            disabled={disabled}
-            className="w-full rounded-lg border-[#668C83] border-[2px] border-opacity-80 px-4 py-8 text-3xl shadow-md"
-            {...field}
-            value={field.value ?? ''}
-            data-testid={dataTestId}
-            onChange={(e) => field.onChange(formatInputText(e.target.value))}
-            onPaste={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              return field.onChange(formatInputText(e.clipboardData.getData('text/plain')));
-            }}
-          />
-        </FormControl>
-        <span className="mx-2 font-light text-5xl">%</span>
-      </div>
-      <FormMessage />
-    </FormItem>
-  );
-}
+    return (
+      <FormItem className="-my-1 flex flex-col">
+        <div className="flex flex-row items-center gap-1 align-middle">
+          <FormControl>
+            <Input
+              placeholder={placeholder}
+              disabled={disabled}
+              className="w-full rounded-lg border-[#668C83] border-[2px] border-opacity-80 px-4 py-8 text-3xl shadow-md"
+              {...field}
+              ref={ref}
+              value={field.value ?? ''}
+              data-testid={dataTestId}
+              onChange={(e) => field.onChange(formatInputText(e.target.value))}
+              onPaste={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                return field.onChange(formatInputText(e.clipboardData.getData('text/plain')));
+              }}
+              {...props}
+            />
+          </FormControl>
+          <span className="mx-2 font-light text-5xl">%</span>
+        </div>
+        <FormMessage />
+      </FormItem>
+    );
+  }
+);

--- a/apps/staking/components/Form/StakeAmountField.tsx
+++ b/apps/staking/components/Form/StakeAmountField.tsx
@@ -72,6 +72,9 @@ export type StakeAmountFieldProps = {
   ignoreBalance?: boolean;
 };
 
+const stakeAmountLeadingZerosRegex = /^0+(?=\d)/;
+const stakeAmountNumericAndDelimitersRegex = /[^0-9.,]/g;
+
 export const StakeAmountField = forwardRef<HTMLInputElement, StakeAmountFieldProps>(
   (
     {
@@ -113,7 +116,7 @@ export const StakeAmountField = forwardRef<HTMLInputElement, StakeAmountFieldPro
     const formatInputText = (value: string) => {
       if (value === '0') return '0';
       // Remove non-numeric characters and non-decimal delimiters
-      let formattedValue = value.replace(/[^0-9.,]/g, '');
+      let formattedValue = value.replace(stakeAmountNumericAndDelimitersRegex, '');
 
       // Remove thousands separators
       if (formattedValue.includes(thousandsSeparator)) {
@@ -122,7 +125,7 @@ export const StakeAmountField = forwardRef<HTMLInputElement, StakeAmountFieldPro
 
       // Remove any leading zeroes except when its `0.` leaving 1 zero if it's all zeros.
       if (formattedValue.startsWith('0') && !formattedValue.startsWith('0.')) {
-        formattedValue = formattedValue.replace(/^0+(?=\d)/, '');
+        formattedValue = formattedValue.replace(stakeAmountLeadingZerosRegex, '');
       }
 
       // Remove all but the first decimal delimiter

--- a/apps/staking/components/Form/StakeAmountField.tsx
+++ b/apps/staking/components/Form/StakeAmountField.tsx
@@ -15,6 +15,7 @@ import { bigIntToNumber, bigIntToString, stringToBigInt } from '@session/util-cr
 import { useWalletTokenBalance } from '@session/wallet/components/WalletButton';
 import { useWallet } from '@session/wallet/hooks/useWallet';
 import { useTranslations } from 'next-intl';
+import { forwardRef } from 'react';
 import { z } from 'zod';
 
 export type GetStakeAmountFormFieldSchemaArgs = {
@@ -71,259 +72,270 @@ export type StakeAmountFieldProps = {
   ignoreBalance?: boolean;
 };
 
-export default function StakeAmountField({
-  dataTestId,
-  dataTestIds,
-  disabled,
-  field,
-  maxStake,
-  minStake,
-  stickiness = 400,
-  watchedStakeAmount,
-  stakeAmountDescription,
-  ignoreBalance,
-}: StakeAmountFieldProps) {
-  const dictionary = useTranslations('general');
-  const dictionaryStakeAmount = useTranslations('actionModules.registration.stakeAmount');
-  const actionModuleSharedDictionary = useTranslations('actionModules.shared');
-  const { isConnected } = useWallet();
+export const StakeAmountField = forwardRef<HTMLInputElement, StakeAmountFieldProps>(
+  (
+    {
+      dataTestId,
+      dataTestIds,
+      disabled,
+      field,
+      maxStake,
+      minStake,
+      stickiness = 400,
+      watchedStakeAmount,
+      stakeAmountDescription,
+      ignoreBalance,
+      ...props
+    },
+    ref
+  ) => {
+    const dictionary = useTranslations('general');
+    const dictionaryStakeAmount = useTranslations('actionModules.registration.stakeAmount');
+    const actionModuleSharedDictionary = useTranslations('actionModules.shared');
+    const { isConnected } = useWallet();
 
-  const { value, onChange } = field;
-  const decimalDelimiter = useDecimalDelimiter();
-  const { balance: balanceWallet, value: balanceWalletValue } = useWalletTokenBalance();
-  const { formattedAmount: balanceVesting, amount: balanceVestingValue } =
-    useVestingUnstakedBalance();
-  const activeVestingContract = useActiveVestingContract();
+    const { value, onChange } = field;
+    const decimalDelimiter = useDecimalDelimiter();
+    const { balance: balanceWallet, value: balanceWalletValue } = useWalletTokenBalance();
+    const { formattedAmount: balanceVesting, amount: balanceVestingValue } =
+      useVestingUnstakedBalance();
+    const activeVestingContract = useActiveVestingContract();
 
-  const balanceValue = activeVestingContract ? balanceVestingValue : balanceWalletValue;
-  const balance = activeVestingContract ? balanceVesting : balanceWallet;
+    const balanceValue = activeVestingContract ? balanceVestingValue : balanceWalletValue;
+    const balance = activeVestingContract ? balanceVesting : balanceWallet;
 
-  const fullStakeString = bigIntToString(
-    SESSION_NODE_FULL_STAKE_AMOUNT,
-    SENT_DECIMALS,
-    decimalDelimiter
-  );
-  const thousandsSeparator = decimalDelimiter === '.' ? ',' : '.';
-  const formatInputText = (value: string) => {
-    if (value === '0') return '0';
-    // Remove non-numeric characters and non-decimal delimiters
-    let formattedValue = value.replace(/[^0-9.,]/g, '');
+    const fullStakeString = bigIntToString(
+      SESSION_NODE_FULL_STAKE_AMOUNT,
+      SENT_DECIMALS,
+      decimalDelimiter
+    );
+    const thousandsSeparator = decimalDelimiter === '.' ? ',' : '.';
+    const formatInputText = (value: string) => {
+      if (value === '0') return '0';
+      // Remove non-numeric characters and non-decimal delimiters
+      let formattedValue = value.replace(/[^0-9.,]/g, '');
 
-    // Remove thousands separators
-    if (formattedValue.includes(thousandsSeparator)) {
-      formattedValue = formattedValue.replaceAll(thousandsSeparator, '');
-    }
+      // Remove thousands separators
+      if (formattedValue.includes(thousandsSeparator)) {
+        formattedValue = formattedValue.replaceAll(thousandsSeparator, '');
+      }
 
-    // Remove any leading zeroes except when its `0.` leaving 1 zero if it's all zeros.
-    if (formattedValue.startsWith('0') && !formattedValue.startsWith('0.')) {
-      formattedValue = formattedValue.replace(/^0+(?=\d)/, '');
-    }
+      // Remove any leading zeroes except when its `0.` leaving 1 zero if it's all zeros.
+      if (formattedValue.startsWith('0') && !formattedValue.startsWith('0.')) {
+        formattedValue = formattedValue.replace(/^0+(?=\d)/, '');
+      }
 
-    // Remove all but the first decimal delimiter
-    if (formattedValue.includes(decimalDelimiter)) {
-      const [first, ...rest] = formattedValue.split(decimalDelimiter);
+      // Remove all but the first decimal delimiter
+      if (formattedValue.includes(decimalDelimiter)) {
+        const [first, ...rest] = formattedValue.split(decimalDelimiter);
 
-      const decimalValue = rest.join('').slice(0, SENT_DECIMALS);
+        const decimalValue = rest.join('').slice(0, SENT_DECIMALS);
 
-      formattedValue = `${first}${decimalDelimiter}${decimalValue}`;
-      // If the value is greater than the full stake, return the full stake
-    }
+        formattedValue = `${first}${decimalDelimiter}${decimalValue}`;
+        // If the value is greater than the full stake, return the full stake
+      }
 
-    if (
-      stringToBigInt(formattedValue, SENT_DECIMALS, decimalDelimiter) >
-      SESSION_NODE_FULL_STAKE_AMOUNT
-    ) {
-      return fullStakeString;
-    }
+      if (
+        stringToBigInt(formattedValue, SENT_DECIMALS, decimalDelimiter) >
+        SESSION_NODE_FULL_STAKE_AMOUNT
+      ) {
+        return fullStakeString;
+      }
 
-    return formattedValue;
-  };
+      return formattedValue;
+    };
 
-  return (
-    <FormItem className="flex flex-col">
-      <FormControl>
-        <div className="flex w-full flex-col items-center gap-2">
-          <div className="flex w-full flex-col flex-wrap justify-between gap-2 text-nowrap md:flex-row">
-            <span className="inline-flex items-center gap-2 text-nowrap align-middle">
-              {actionModuleSharedDictionary('stakeAmount')}
-              <ActionModuleTooltip>
-                {stakeAmountDescription ?? actionModuleSharedDictionary('stakeAmountDescription')}
-              </ActionModuleTooltip>
-              {!ignoreBalance &&
-              watchedStakeAmount &&
-              balanceValue !== undefined &&
-              balanceValue < stringToBigInt(watchedStakeAmount, SENT_DECIMALS) ? (
-                <AlertTooltip
-                  tooltipContent={dictionary('error.InsufficientBalance', {
-                    walletAmount: balance,
-                    tokenAmount: formatSENTBigInt(
-                      stringToBigInt(watchedStakeAmount, SENT_DECIMALS)
-                    ),
+    return (
+      <FormItem className="flex flex-col">
+        <FormControl>
+          <div className="flex w-full flex-col items-center gap-2">
+            <div className="flex w-full flex-col flex-wrap justify-between gap-2 text-nowrap md:flex-row">
+              <span className="inline-flex items-center gap-2 text-nowrap align-middle">
+                {actionModuleSharedDictionary('stakeAmount')}
+                <ActionModuleTooltip>
+                  {stakeAmountDescription ?? actionModuleSharedDictionary('stakeAmountDescription')}
+                </ActionModuleTooltip>
+                {!ignoreBalance &&
+                watchedStakeAmount &&
+                balanceValue !== undefined &&
+                balanceValue < stringToBigInt(watchedStakeAmount, SENT_DECIMALS) ? (
+                  <AlertTooltip
+                    tooltipContent={dictionary('error.InsufficientBalance', {
+                      walletAmount: balance,
+                      tokenAmount: formatSENTBigInt(
+                        stringToBigInt(watchedStakeAmount, SENT_DECIMALS)
+                      ),
+                    })}
+                  />
+                ) : null}
+              </span>
+              <div className="self-end">
+                <Button
+                  size="xs"
+                  rounded="lg"
+                  variant="ghost"
+                  type="button"
+                  className="gap-1 px-2"
+                  disabled={disabled}
+                  data-testid={dataTestIds.buttonMin}
+                  onClick={() =>
+                    onChange(
+                      formatInputText(bigIntToString(minStake, SENT_DECIMALS, decimalDelimiter))
+                    )
+                  }
+                >
+                  {dictionaryStakeAmount.rich('min', {
+                    min: formatSENTBigIntNoRounding(minStake),
                   })}
-                />
-              ) : null}
-            </span>
-            <div className="self-end">
-              <Button
-                size="xs"
-                rounded="lg"
-                variant="ghost"
-                type="button"
-                className="gap-1 px-2"
-                disabled={disabled}
-                data-testid={dataTestIds.buttonMin}
-                onClick={() =>
-                  onChange(
-                    formatInputText(bigIntToString(minStake, SENT_DECIMALS, decimalDelimiter))
-                  )
-                }
-              >
-                {dictionaryStakeAmount.rich('min', {
-                  min: formatSENTBigIntNoRounding(minStake),
-                })}
-              </Button>
-              {'|'}
-              <Button
-                size="xs"
-                rounded="lg"
-                variant="ghost"
-                type="button"
-                className="gap-1 px-2"
-                disabled={disabled}
-                data-testid={dataTestIds.buttonMax}
-                onClick={() =>
-                  onChange(
-                    formatInputText(bigIntToString(maxStake, SENT_DECIMALS, decimalDelimiter))
-                  )
-                }
-              >
-                {dictionaryStakeAmount.rich('max', {
-                  max: formatSENTBigIntNoRounding(maxStake),
-                })}
-              </Button>
+                </Button>
+                {'|'}
+                <Button
+                  size="xs"
+                  rounded="lg"
+                  variant="ghost"
+                  type="button"
+                  className="gap-1 px-2"
+                  disabled={disabled}
+                  data-testid={dataTestIds.buttonMax}
+                  onClick={() =>
+                    onChange(
+                      formatInputText(bigIntToString(maxStake, SENT_DECIMALS, decimalDelimiter))
+                    )
+                  }
+                >
+                  {dictionaryStakeAmount.rich('max', {
+                    max: formatSENTBigIntNoRounding(maxStake),
+                  })}
+                </Button>
+              </div>
             </div>
+            <Input
+              placeholder={bigIntToString(maxStake, SENT_DECIMALS)}
+              disabled={!isConnected || disabled}
+              className="w-full rounded-lg border-[#668C83] border-[2px] border-opacity-80 px-4 py-8 text-3xl shadow-md"
+              {...field}
+              value={value}
+              onChange={(e) => onChange(formatInputText(e.target.value))}
+              onPaste={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                return onChange(formatInputText(e.clipboardData.getData('text/plain')));
+              }}
+              ref={ref}
+              data-testid={dataTestId}
+              {...props}
+            />
+            <Slider
+              className="my-2"
+              max={bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS)}
+              step={1}
+              disabled={disabled}
+              value={[
+                bigIntToNumber(
+                  stringToBigInt(value, SENT_DECIMALS, decimalDelimiter),
+                  SENT_DECIMALS
+                ),
+              ]}
+              dataTestIds={{
+                slider0: dataTestIds.slider0,
+                slider25: dataTestIds.slider25,
+                slider50: dataTestIds.slider50,
+                slider75: dataTestIds.slider75,
+                slider100: dataTestIds.slider100,
+              }}
+              onValueChange={([val]) => {
+                if (!val) return;
+
+                const distanceToMax = Math.abs(bigIntToNumber(maxStake, SENT_DECIMALS) - val);
+                if (distanceToMax < stickiness) {
+                  return onChange(bigIntToString(maxStake, SENT_DECIMALS, decimalDelimiter));
+                }
+
+                const distanceToMin = Math.abs(bigIntToNumber(minStake, SENT_DECIMALS) - val);
+                if (distanceToMin < stickiness) {
+                  return onChange(bigIntToString(minStake, SENT_DECIMALS, decimalDelimiter));
+                }
+
+                if (val < stickiness) {
+                  return onChange('0');
+                }
+
+                const distanceTo50 = Math.abs(
+                  bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS) / 2 - val
+                );
+                if (distanceTo50 < stickiness) {
+                  return onChange(
+                    bigIntToString(
+                      SESSION_NODE_FULL_STAKE_AMOUNT / BigInt(2),
+                      SENT_DECIMALS,
+                      decimalDelimiter
+                    )
+                  );
+                }
+
+                const distanceTo25 = Math.abs(
+                  bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS) / 4 - val
+                );
+                if (distanceTo25 < stickiness) {
+                  return onChange(
+                    bigIntToString(
+                      SESSION_NODE_FULL_STAKE_AMOUNT / BigInt(4),
+                      SENT_DECIMALS,
+                      decimalDelimiter
+                    )
+                  );
+                }
+
+                const distanceTo75 = Math.abs(
+                  (bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS) / 4) * 3 - val
+                );
+                if (distanceTo75 < stickiness) {
+                  return onChange(
+                    bigIntToString(
+                      (SESSION_NODE_FULL_STAKE_AMOUNT / BigInt(4)) * BigInt(3),
+                      SENT_DECIMALS,
+                      decimalDelimiter
+                    )
+                  );
+                }
+
+                const distanceTo100 = Math.abs(
+                  (bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS) / 100) * 100 - val
+                );
+                if (distanceTo100 < stickiness) {
+                  return onChange(
+                    bigIntToString(
+                      (SESSION_NODE_FULL_STAKE_AMOUNT / BigInt(100)) * BigInt(100),
+                      SENT_DECIMALS,
+                      decimalDelimiter
+                    )
+                  );
+                }
+
+                return onChange(val.toString());
+              }}
+            >
+              <SliderLineCircle
+                variant="blue"
+                strokeVariant="blue"
+                data-testid={dataTestIds.sliderMax}
+                style={{
+                  left: `calc(${(bigIntToNumber(maxStake, SENT_DECIMALS) / bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS)) * 100}% - 8px)`,
+                }}
+              />
+              <SliderLineCircle
+                variant="blue"
+                strokeVariant="blue"
+                data-testid={dataTestIds.sliderMin}
+                style={{
+                  left: `calc(${(bigIntToNumber(minStake, SENT_DECIMALS) / bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS)) * 100}%)`,
+                }}
+              />
+            </Slider>
           </div>
-          <Input
-            placeholder={bigIntToString(maxStake, SENT_DECIMALS)}
-            disabled={!isConnected || disabled}
-            className="w-full rounded-lg border-[#668C83] border-[2px] border-opacity-80 px-4 py-8 text-3xl shadow-md"
-            {...field}
-            value={value}
-            onChange={(e) => onChange(formatInputText(e.target.value))}
-            onPaste={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              return onChange(formatInputText(e.clipboardData.getData('text/plain')));
-            }}
-            data-testid={dataTestId}
-          />
-          <Slider
-            className="my-2"
-            max={bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS)}
-            step={1}
-            disabled={disabled}
-            value={[
-              bigIntToNumber(stringToBigInt(value, SENT_DECIMALS, decimalDelimiter), SENT_DECIMALS),
-            ]}
-            dataTestIds={{
-              slider0: dataTestIds.slider0,
-              slider25: dataTestIds.slider25,
-              slider50: dataTestIds.slider50,
-              slider75: dataTestIds.slider75,
-              slider100: dataTestIds.slider100,
-            }}
-            onValueChange={([val]) => {
-              if (!val) return;
-
-              const distanceToMax = Math.abs(bigIntToNumber(maxStake, SENT_DECIMALS) - val);
-              if (distanceToMax < stickiness) {
-                return onChange(bigIntToString(maxStake, SENT_DECIMALS, decimalDelimiter));
-              }
-
-              const distanceToMin = Math.abs(bigIntToNumber(minStake, SENT_DECIMALS) - val);
-              if (distanceToMin < stickiness) {
-                return onChange(bigIntToString(minStake, SENT_DECIMALS, decimalDelimiter));
-              }
-
-              if (val < stickiness) {
-                return onChange('0');
-              }
-
-              const distanceTo50 = Math.abs(
-                bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS) / 2 - val
-              );
-              if (distanceTo50 < stickiness) {
-                return onChange(
-                  bigIntToString(
-                    SESSION_NODE_FULL_STAKE_AMOUNT / BigInt(2),
-                    SENT_DECIMALS,
-                    decimalDelimiter
-                  )
-                );
-              }
-
-              const distanceTo25 = Math.abs(
-                bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS) / 4 - val
-              );
-              if (distanceTo25 < stickiness) {
-                return onChange(
-                  bigIntToString(
-                    SESSION_NODE_FULL_STAKE_AMOUNT / BigInt(4),
-                    SENT_DECIMALS,
-                    decimalDelimiter
-                  )
-                );
-              }
-
-              const distanceTo75 = Math.abs(
-                (bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS) / 4) * 3 - val
-              );
-              if (distanceTo75 < stickiness) {
-                return onChange(
-                  bigIntToString(
-                    (SESSION_NODE_FULL_STAKE_AMOUNT / BigInt(4)) * BigInt(3),
-                    SENT_DECIMALS,
-                    decimalDelimiter
-                  )
-                );
-              }
-
-              const distanceTo100 = Math.abs(
-                (bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS) / 100) * 100 - val
-              );
-              if (distanceTo100 < stickiness) {
-                return onChange(
-                  bigIntToString(
-                    (SESSION_NODE_FULL_STAKE_AMOUNT / BigInt(100)) * BigInt(100),
-                    SENT_DECIMALS,
-                    decimalDelimiter
-                  )
-                );
-              }
-
-              return onChange(val.toString());
-            }}
-          >
-            <SliderLineCircle
-              variant="blue"
-              strokeVariant="blue"
-              data-testid={dataTestIds.sliderMax}
-              style={{
-                left: `calc(${(bigIntToNumber(maxStake, SENT_DECIMALS) / bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS)) * 100}% - 8px)`,
-              }}
-            />
-            <SliderLineCircle
-              variant="blue"
-              strokeVariant="blue"
-              data-testid={dataTestIds.sliderMin}
-              style={{
-                left: `calc(${(bigIntToNumber(minStake, SENT_DECIMALS) / bigIntToNumber(SESSION_NODE_FULL_STAKE_AMOUNT, SENT_DECIMALS)) * 100}%)`,
-              }}
-            />
-          </Slider>
-        </div>
-      </FormControl>
-      <FormMessage />
-    </FormItem>
-  );
-}
+        </FormControl>
+        <FormMessage />
+      </FormItem>
+    );
+  }
+);

--- a/apps/staking/components/StakedNodeCard.tsx
+++ b/apps/staking/components/StakedNodeCard.tsx
@@ -212,9 +212,9 @@ const ReadyForExitNotification = ({
     >
       <NodeNotification level={isLiquidationSoon ? 'error' : 'warning'} className={className}>
         {isLiquidationSoon
-          ? dictionary.rich(isDeregistered ? 'liquidationNotification' : 'exitTimerNotificationNow')
+          ? dictionary.rich('exitTimerNotificationNow')
           : dictionary.rich(
-              isDeregistered ? 'deregistrationTimerDescription' : 'exitTimerNotification',
+              'exitTimerNotification',
               { relativeTime }
             )}
       </NodeNotification>

--- a/apps/staking/components/StakedNodeCard.tsx
+++ b/apps/staking/components/StakedNodeCard.tsx
@@ -614,7 +614,7 @@ const StakedNodeCard = forwardRef<
               </Tooltip>
             </CollapsableContent>
           ) : null}
-          {lastUptimeProofSeconds || state === STAKE_STATE.RUNNING ? (
+          {lastUptimeProofSeconds ? (
             <CollapsableContent size="xs">
               <Tooltip
                 tooltipContent={dictionary('lastUptimeDescription', {

--- a/apps/staking/components/StakedNodeCard.tsx
+++ b/apps/staking/components/StakedNodeCard.tsx
@@ -213,10 +213,7 @@ const ReadyForExitNotification = ({
       <NodeNotification level={isLiquidationSoon ? 'error' : 'warning'} className={className}>
         {isLiquidationSoon
           ? dictionary.rich('exitTimerNotificationNow')
-          : dictionary.rich(
-              'exitTimerNotification',
-              { relativeTime }
-            )}
+          : dictionary.rich('exitTimerNotification', { relativeTime })}
       </NodeNotification>
     </Tooltip>
   );

--- a/apps/staking/components/Vesting/TransferOwnerDialog.tsx
+++ b/apps/staking/components/Vesting/TransferOwnerDialog.tsx
@@ -1,5 +1,6 @@
 import { ActionModuleRow } from '@/components/ActionModule';
-import EthereumAddressField, {
+import {
+  EthereumAddressField,
   getEthereumAddressFormFieldSchema,
 } from '@/components/Form/EthereumAddressField';
 import { TextWithInlineEnder } from '@/components/TextWithInlineEnder';


### PR DESCRIPTION
This pull request introduces several updates to the staking application, focusing on improving the codebase's maintainability, enhancing user interactions, and ensuring consistent coding practices. The key changes include refactoring imports, implementing new callbacks and refs for better field editing, and converting components to use `forwardRef` for improved flexibility.

### Refactoring and Code Consistency:
* Updated all imports of `EthereumAddressField` and `StakeAmountField` to use named imports for consistency across files.
* Converted `StakeInfo` and other components to use `forwardRef` to enable passing refs, improving component flexibility. 

### User Interaction Enhancements:
* Added `useRef` and `useCallback` in `ManageStake` to enable smooth scrolling and focusing on editable fields, improving the user experience when editing fields like `stakeAmount` and `rewardsAddress`. 
* Passed refs (`stakeAmountRef`, `rewardsAddressRef`) to `ManageStakeContribution` for better field handling in forms. 

### UI Enhancements:
* Replaced plain text with the `Typography` component in `NoticeModule` for better styling and readability.
* Improved tooltips and aria-label formatting for accessibility and code clarity. 

### Minor Improvements:
* Updated `disabledReason` in `SubmitMultiTab` to use `dictReservedSlotsTab.rich` for richer text formatting. 
* Added `useCallback` and `useRef` imports in `ManageStake` for new ref-based functionality.