### PR TITLE
feat: add mainnet contracts

### DIFF
--- a/packages/contracts/constants.ts
+++ b/packages/contracts/constants.ts
@@ -21,47 +21,37 @@ export type ChainId = typeof ethChainId | typeof arbitrumChainId | typeof arbitr
 export const isValidChainId = (chainId?: number | undefined): chainId is ChainId =>
   chainId === arbitrumChainId || chainId === arbitrumSepoliaChainId || chainId === ethChainId;
 
-// TODO - Replace Mainnet addresses with the correct addresses once they are available
 export const addresses: Record<ContractName, Record<ChainId, Address>> = {
   Token: {
-    /** @deprecated - The Mainnet value is a mock value */
-    [arbitrumChainId]: '0x7D7fD4E91834A96cD9Fb2369E7f4EB72383bbdEd',
-    /** @deprecated - The Eth value is a mock value */
-    [ethChainId]: '0x7D7fD4E91834A96cD9Fb2369E7f4EB72383bbdEd',
+    [arbitrumChainId]: '0x10Ea9E5303670331Bdddfa66A4cEA47dae4fcF3b',
+    [ethChainId]: '0x10Ea9E5303670331Bdddfa66A4cEA47dae4fcF3b',
     [arbitrumSepoliaChainId]: '0x7D7fD4E91834A96cD9Fb2369E7f4EB72383bbdEd',
   },
   ServiceNodeRewards: {
-    /** @deprecated - The Mainnet value is a mock value */
-    [arbitrumChainId]: '0x9d8aB00880CBBdc2Dcd29C179779469A82E7be35',
-    /** @deprecated - The Eth value is a mock value */
-    [ethChainId]: '0x9d8aB00880CBBdc2Dcd29C179779469A82E7be35',
+    [arbitrumChainId]: '0xC2B9fC251aC068763EbDfdecc792E3352E351c00',
+    /** @deprecated - The contract is not deployed on eth mainnet */
+    [ethChainId]: '0x0000000000000000000000000000000000000000',
     [arbitrumSepoliaChainId]: '0x9d8aB00880CBBdc2Dcd29C179779469A82E7be35',
   },
   RewardRatePool: {
-    /** @deprecated - The Mainnet value is a mock value */
-    [arbitrumChainId]: '0xaAD853fE7091728dac0DAa7b69990ee68abFC636',
-    /** @deprecated - The Eth value is a mock value */
-    [ethChainId]: '0xaAD853fE7091728dac0DAa7b69990ee68abFC636',
+    [arbitrumChainId]: '0x11f040E89dFAbBA9070FFE6145E914AC68DbFea0',
+    /** @deprecated - The contract is not deployed on eth mainnet */
+    [ethChainId]: '0x0000000000000000000000000000000000000000',
     [arbitrumSepoliaChainId]: '0xaAD853fE7091728dac0DAa7b69990ee68abFC636',
   },
   ServiceNodeContributionFactory: {
-    /** @deprecated - The Mainnet value is a mock value */
-    [arbitrumChainId]: '0x36Ee2Da54a7E727cC996A441826BBEdda6336B71',
-    /** @deprecated - The Eth value is a mock value */
-    [ethChainId]: '0x36Ee2Da54a7E727cC996A441826BBEdda6336B71',
+    [arbitrumChainId]: '0x8129bE2D5eF7ACd39483C19F28DE86b7EF19DBCA',
+    /** @deprecated - The contract is not deployed on eth mainnet */
+    [ethChainId]: '0x0000000000000000000000000000000000000000',
     [arbitrumSepoliaChainId]: '0x36Ee2Da54a7E727cC996A441826BBEdda6336B71',
   },
   ServiceNodeContribution: {
-    /** @deprecated - The Mainnet value is a mock value */
     [arbitrumChainId]: '0x0000000000000000000000000000000000000000',
-    /** @deprecated - The Eth value is a mock value */
     [ethChainId]: '0x0000000000000000000000000000000000000000',
     [arbitrumSepoliaChainId]: '0x0000000000000000000000000000000000000000',
   },
   TokenVestingStaking: {
-    /** @deprecated - The Mainnet value is a mock value */
     [arbitrumChainId]: '0x0000000000000000000000000000000000000000',
-    /** @deprecated - The Eth value is a mock value */
     [ethChainId]: '0x0000000000000000000000000000000000000000',
     [arbitrumSepoliaChainId]: '0x0000000000000000000000000000000000000000',
   },

--- a/packages/wallet/providers/web3wallet-provider.tsx
+++ b/packages/wallet/providers/web3wallet-provider.tsx
@@ -104,7 +104,7 @@ function TokenActionButton({ href, children }: { href: string; children: ReactNo
 }
 
 const tokenDetailsArbitrum: DynamicTokenRowProps = {
-  tokenAddress: '0x7D7fD4E91834A96cD9Fb2369E7f4EB72383bbdEd',
+  tokenAddress: '0x10Ea9E5303670331Bdddfa66A4cEA47dae4fcF3b',
   name: 'Session Token',
   iconSrc: 'https://stake.getsession.org/images/token_logo.svg',
   showAddTokenButton: true,
@@ -131,7 +131,7 @@ const tokenDetailsArbitrumSepolia: DynamicTokenRowProps = {
 };
 
 const tokenDetailsEthereum: DynamicTokenRowProps = {
-  tokenAddress: '0x0DBD22764C6C77827B4D03482998CA2dd61b5294',
+  tokenAddress: '0x10Ea9E5303670331Bdddfa66A4cEA47dae4fcF3b',
   name: 'Session Token',
   iconSrc: 'https://stake.getsession.org/images/token_logo.svg',
   showAddTokenButton: true,


### PR DESCRIPTION
This pull request updates contract addresses for various Ethereum and Arbitrum networks to replace mock values with actual deployed contract addresses. It also updates token details in the wallet provider to reflect these changes.

### Updates to Contract Addresses:

* [`packages/contracts/constants.ts`](diffhunk://#diff-9d35a9851a713be83d906bd840a55c325abe3af69a29649cc58723df7dc911f1L24-L64): Replaced mock contract addresses with actual deployed addresses for `arbitrumChainId` and `ethChainId`. For contracts not deployed on Ethereum mainnet, addresses are set to `0x0000000000000000000000000000000000000000`.

### Updates to Token Details:

* [`packages/wallet/providers/web3wallet-provider.tsx`](diffhunk://#diff-807e0a6b63093b0456356680b966d26ee10cb93da92a7e3f9d4006b95e119386L107-R107): Updated the `tokenAddress` for `tokenDetailsArbitrum` to the new deployed address.
* [`packages/wallet/providers/web3wallet-provider.tsx`](diffhunk://#diff-807e0a6b63093b0456356680b966d26ee10cb93da92a7e3f9d4006b95e119386L134-R134): Updated the `tokenAddress` for `tokenDetailsEthereum` to the new deployed address.