### PR TITLE
Feat: react utilties and custom hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This repository contains the following apps and packages:
 - `@session/util-js`: A JS utility library for common functions. [Read more](packages/util-js/README.md).
 - `@session/util-logger`: A logger utility library for initializing the pino logger with @session/logger as a
   wrapper. [Read more](packages/util-logger/README.md).
+- `@session/util-react`: A react utility library.
 - `@session/wallet`: A wallet library for interacting with the Session Token. [Read more](packages/wallet/README.md).
 
 ### Utilities

--- a/apps/staking/app/mystakes/modules/StakedNodesModule.tsx
+++ b/apps/staking/app/mystakes/modules/StakedNodesModule.tsx
@@ -7,7 +7,7 @@ import {
   getStakedContractCardContractFromConfirmation,
 } from '@/components/StakedNode/StakedContractCard';
 import { StakedNodeCard } from '@/components/StakedNodeCard';
-import { useStatusBarVisible } from '@/components/StatusBar';
+import { useDisplayStatusBar } from '@/components/StatusBar';
 import WalletButtonWithLocales from '@/components/WalletButtonWithLocales';
 import { useStakes } from '@/hooks/useStakes';
 import { EXPERIMENTAL_FEATURE_FLAG } from '@/lib/feature-flags';
@@ -47,7 +47,7 @@ export function StakedNodesWithAddress({ address }: { address: Address }) {
     refetch,
     isError,
   } = useStakes(address);
-  useStatusBarVisible({ network, isLoading, isFetching, refetch });
+  useDisplayStatusBar({ network, isLoading, isFetching, refetch });
 
   const hasStakes =
     stakes?.length ||

--- a/apps/staking/app/mystakes/modules/StakedNodesModule.tsx
+++ b/apps/staking/app/mystakes/modules/StakedNodesModule.tsx
@@ -7,7 +7,7 @@ import {
   getStakedContractCardContractFromConfirmation,
 } from '@/components/StakedNode/StakedContractCard';
 import { StakedNodeCard } from '@/components/StakedNodeCard';
-import { useNetworkStatus } from '@/components/StatusBar';
+import { useStatusBarVisible } from '@/components/StatusBar';
 import WalletButtonWithLocales from '@/components/WalletButtonWithLocales';
 import { useStakes } from '@/hooks/useStakes';
 import { EXPERIMENTAL_FEATURE_FLAG } from '@/lib/feature-flags';
@@ -28,7 +28,6 @@ import { useWallet } from '@session/wallet/hooks/useWallet';
 import { useTranslations } from 'next-intl';
 import { ErrorBoundary } from 'next/dist/client/components/error-boundary';
 import Link from 'next/link';
-import { useEffect } from 'react';
 import type { Address } from 'viem';
 
 export function StakedNodesWithAddress({ address }: { address: Address }) {
@@ -48,15 +47,7 @@ export function StakedNodesWithAddress({ address }: { address: Address }) {
     refetch,
     isError,
   } = useStakes(address);
-  const { setNetworkStatusVisible } = useNetworkStatus({ network, isLoading, isFetching, refetch });
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On mount
-  useEffect(() => {
-    setNetworkStatusVisible(true);
-    return () => {
-      setNetworkStatusVisible(false);
-    };
-  }, []);
+  useStatusBarVisible({ network, isLoading, isFetching, refetch });
 
   const hasStakes =
     stakes?.length ||

--- a/apps/staking/app/register/NodeRegistrations.tsx
+++ b/apps/staking/app/register/NodeRegistrations.tsx
@@ -16,6 +16,7 @@ import { useAllowTestingErrorToThrow } from '@/lib/testing';
 import { ButtonDataTestId } from '@/testing/data-test-ids';
 import { ModuleGridInfoContent } from '@session/ui/components/ModuleGrid';
 import { safeTrySyncWithFallback } from '@session/util-js/try';
+import { useMount } from '@session/util-react/hooks/useMount';
 import { useWallet } from '@session/wallet/hooks/useWallet';
 import { useTranslations } from 'next-intl';
 import { useEffect, useMemo } from 'react';
@@ -72,15 +73,14 @@ export default function NodeRegistrations() {
       });
   }, [networkBlsKeys, data, showNoNodes, isLoadingStakes]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On mount
-  useEffect(() => {
+  useMount(() => {
     if (isConnected) {
       setNetworkStatusVisible(true);
     }
     return () => {
       setNetworkStatusVisible(false);
     };
-  }, []);
+  });
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: On connected state change
   useEffect(() => {

--- a/apps/staking/app/register/[nodeId]/Registration.tsx
+++ b/apps/staking/app/register/[nodeId]/Registration.tsx
@@ -66,6 +66,7 @@ import { useForm } from '@session/ui/ui/form';
 import { bigIntMin, bigIntToString, stringToBigInt } from '@session/util-crypto/maths';
 import { areHexesEqual } from '@session/util-crypto/string';
 import { safeTrySync } from '@session/util-js/try';
+import { useMount } from '@session/util-react/hooks/useMount';
 import { useWalletTokenBalance } from '@session/wallet/components/WalletButton';
 import { useWallet } from '@session/wallet/hooks/useWallet';
 import { useWalletButton } from '@session/wallet/providers/wallet-button-provider';
@@ -76,7 +77,6 @@ import {
   type SetStateAction,
   createContext,
   useContext,
-  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -572,11 +572,10 @@ export function RegistrationWizard() {
     : null;
   const sectionDescription2 = dict.has('description2') ? dict.rich('description2') : null;
 
-  /** While the component is mounted, show the balance */
-  useEffect(() => {
+  useMount(() => {
     setIsBalanceVisible(true);
     return () => setIsBalanceVisible(false);
-  }, [setIsBalanceVisible]);
+  });
 
   return acceptedNotice ? (
     <WizardContent

--- a/apps/staking/app/register/[nodeId]/multi/AutoActivateTab.tsx
+++ b/apps/staking/app/register/[nodeId]/multi/AutoActivateTab.tsx
@@ -5,8 +5,9 @@ import {
 import { REG_MODE, REG_TAB } from '@/app/register/[nodeId]/types';
 import { ButtonDataTestId } from '@/testing/data-test-ids';
 import { Button } from '@session/ui/ui/button';
+import { useMount } from '@session/util-react/hooks/useMount';
 import { useTranslations } from 'next-intl';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 export function AutoActivateTab() {
   const { mode, changeTab, formMulti, setBackButtonClickCallback, pushQueryParam } =
@@ -28,11 +29,10 @@ export function AutoActivateTab() {
     changeTab(REG_TAB.SUBMIT_MULTI);
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On mount
-  useEffect(() => {
+  useMount(() => {
     setBackButtonClickCallback(() => handleBackButtonClick);
     return () => setBackButtonClickCallback(null);
-  }, []);
+  });
 
   return (
     <div className="flex w-full flex-col gap-4">

--- a/apps/staking/app/register/[nodeId]/multi/OperatorFeeTab.tsx
+++ b/apps/staking/app/register/[nodeId]/multi/OperatorFeeTab.tsx
@@ -9,8 +9,9 @@ import { SESSION_NODE } from '@/lib/constants';
 import { ButtonDataTestId, InputDataTestId } from '@/testing/data-test-ids';
 import { Form, FormField } from '@session/ui/components/ui/form';
 import { Button } from '@session/ui/ui/button';
+import { useMount } from '@session/util-react/hooks/useMount';
 import { useTranslations } from 'next-intl';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 export function OperatorFeeTab() {
   const { formMulti, changeTab, mode, setBackButtonClickCallback, pushQueryParam, isVestingMode } =
@@ -39,11 +40,10 @@ export function OperatorFeeTab() {
     }
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On mount
-  useEffect(() => {
+  useMount(() => {
     setBackButtonClickCallback(() => handleBackButtonClick);
     return () => setBackButtonClickCallback(null);
-  }, []);
+  });
 
   const fieldStatus = formMulti.getFieldState('operatorFee');
 

--- a/apps/staking/app/register/[nodeId]/multi/ReserveSlotsInputTab.tsx
+++ b/apps/staking/app/register/[nodeId]/multi/ReserveSlotsInputTab.tsx
@@ -29,8 +29,9 @@ import { Form, FormField, useForm } from '@session/ui/ui/form';
 import { bigIntToString, stringToBigInt } from '@session/util-crypto/maths';
 import { areHexesEqual } from '@session/util-crypto/string';
 import { safeTrySync } from '@session/util-js/try';
+import { useMount } from '@session/util-react/hooks/useMount';
 import { useTranslations } from 'next-intl';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { isAddress } from 'viem';
 import { z } from 'zod';
 
@@ -259,11 +260,10 @@ export function ReserveSlotsInputTab() {
     setIsNewSlotFormVisible(true);
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On mount
-  useEffect(() => {
+  useMount(() => {
     setBackButtonClickCallback(() => handleBackButtonClick);
     return () => setBackButtonClickCallback(null);
-  }, []);
+  });
 
   const canReserveSlots =
     reservedStakes.length < SESSION_NODE.MAX_CONTRIBUTORS &&

--- a/apps/staking/app/register/[nodeId]/multi/RewardsAddressInputMultiTab.tsx
+++ b/apps/staking/app/register/[nodeId]/multi/RewardsAddressInputMultiTab.tsx
@@ -8,8 +8,9 @@ import { EthereumAddressField } from '@/components/Form/EthereumAddressField';
 import { ButtonDataTestId, InputDataTestId } from '@/testing/data-test-ids';
 import { Form, FormField } from '@session/ui/components/ui/form';
 import { Button } from '@session/ui/ui/button';
+import { useMount } from '@session/util-react/hooks/useMount';
 import { useTranslations } from 'next-intl';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 export function RewardsAddressInputMultiTab() {
   const { formMulti, changeTab, mode, setBackButtonClickCallback, pushQueryParam } =
@@ -35,11 +36,10 @@ export function RewardsAddressInputMultiTab() {
     );
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On mount
-  useEffect(() => {
+  useMount(() => {
     setBackButtonClickCallback(() => handleBackButtonClick);
     return () => setBackButtonClickCallback(null);
-  }, []);
+  });
 
   return (
     <div className="flex w-full flex-col gap-6">

--- a/apps/staking/app/register/[nodeId]/multi/StakeAmountTab.tsx
+++ b/apps/staking/app/register/[nodeId]/multi/StakeAmountTab.tsx
@@ -14,8 +14,9 @@ import { TOKEN } from '@session/contracts';
 import { Form, FormField } from '@session/ui/components/ui/form';
 import { Button } from '@session/ui/ui/button';
 import { stringToBigInt } from '@session/util-crypto/maths';
+import { useMount } from '@session/util-react/hooks/useMount';
 import { useTranslations } from 'next-intl';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 const FIELD_NAME = 'stakeAmount';
 
@@ -63,11 +64,10 @@ export function StakeAmountTab() {
     changeTab(mode === REG_MODE.EDIT ? REG_TAB.SUBMIT_MULTI : REG_TAB.OPERATOR_FEE);
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On mount
-  useEffect(() => {
+  useMount(() => {
     setBackButtonClickCallback(() => handleBackButtonClick);
     return () => setBackButtonClickCallback(null);
-  }, []);
+  });
 
   return (
     <div className="flex w-full flex-col gap-6">

--- a/apps/staking/app/register/[nodeId]/shared/AlreadyRegisteredRunningTab.tsx
+++ b/apps/staking/app/register/[nodeId]/shared/AlreadyRegisteredRunningTab.tsx
@@ -10,9 +10,9 @@ import { ButtonDataTestId } from '@/testing/data-test-ids';
 import { Loading } from '@session/ui/components/loading';
 import { Button } from '@session/ui/ui/button';
 import { areHexesEqual } from '@session/util-crypto/string';
+import { useMount } from '@session/util-react/hooks/useMount';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import { useEffect } from 'react';
 
 export function AlreadyRegisteredRunningTab() {
   const { props } = useRegistrationWizard();
@@ -34,10 +34,9 @@ export function AlreadyRegisteredRunningTab() {
     areHexesEqual(stake.service_node_pubkey, props.ed25519PubKey)
   );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On mount
-  useEffect(() => {
+  useMount(() => {
     if (!stake) void refetch();
-  }, []);
+  });
 
   return (
     <div className="flex w-full flex-col items-center gap-6">

--- a/apps/staking/app/register/[nodeId]/solo/RewardsAddressInputSoloTab.tsx
+++ b/apps/staking/app/register/[nodeId]/solo/RewardsAddressInputSoloTab.tsx
@@ -4,8 +4,9 @@ import { EthereumAddressField } from '@/components/Form/EthereumAddressField';
 import { ButtonDataTestId, InputDataTestId } from '@/testing/data-test-ids';
 import { Form, FormField } from '@session/ui/components/ui/form';
 import { Button } from '@session/ui/ui/button';
+import { useMount } from '@session/util-react/hooks/useMount';
 import { useTranslations } from 'next-intl';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 export function RewardsAddressInputSoloTab() {
   const { formSolo, changeTab, setBackButtonClickCallback } = useRegistrationWizard();
@@ -19,11 +20,10 @@ export function RewardsAddressInputSoloTab() {
     formSolo.setValue('rewardsAddress', initialRewardsAddress.current);
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On mount
-  useEffect(() => {
+  useMount(() => {
     setBackButtonClickCallback(() => handleBackButtonClick);
     return () => setBackButtonClickCallback(null);
-  }, []);
+  });
 
   return (
     <div className="flex w-full flex-col gap-6">

--- a/apps/staking/app/register/[nodeId]/solo/useSubmitSolo.tsx
+++ b/apps/staking/app/register/[nodeId]/solo/useSubmitSolo.tsx
@@ -7,7 +7,9 @@ import { SESSION_NODE } from '@/lib/constants';
 import { useNodesWithConfirmations } from '@/lib/volatile-storage';
 import { getContractErrorName } from '@session/contracts';
 import { areHexesEqual } from '@session/util-crypto/string';
-import { useEffect, useMemo, useState } from 'react';
+import { useMount } from '@session/util-react/hooks/useMount';
+import { useMemo, useState } from 'react';
+import { useEffect } from 'react';
 
 type SubmitSoloProps = {
   error?: Error | null;
@@ -75,13 +77,12 @@ export function useSubmitSolo({
     registerAndStake();
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On mount
-  useEffect(() => {
+  useMount(() => {
     if (!enabled) {
       setIsSubmitting(true);
       registerAndStake();
     }
-  }, []);
+  });
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: On confirmation change
   useEffect(() => {

--- a/apps/staking/app/stake/OpenNodes.tsx
+++ b/apps/staking/app/stake/OpenNodes.tsx
@@ -7,7 +7,7 @@ import {
 import { ErrorMessage } from '@/components/ErrorMessage';
 import { NodesListSkeleton } from '@/components/NodesListModule';
 import { OpenNodeCard } from '@/components/OpenNodeCard';
-import { useStatusBarVisible } from '@/components/StatusBar';
+import { useDisplayStatusBar } from '@/components/StatusBar';
 import { useCurrentActor } from '@/hooks/useCurrentActor';
 import { useOpenContributorContracts } from '@/hooks/useOpenContributorContracts';
 import { useStakes } from '@/hooks/useStakes';
@@ -31,7 +31,7 @@ export default function OpenNodes() {
   const address = useCurrentActor();
   const { contracts, network, isFetching, refetch, isError, isLoading } =
     useOpenContributorContracts(address);
-  useStatusBarVisible({ network, isFetching, refetch });
+  useDisplayStatusBar({ network, isFetching, refetch });
   const { hiddenContractsWithStakes, awaitingOperatorContracts } = useStakes(address);
 
   const { enabled: isStakingDisabled } = useRemoteFeatureFlagQuery(

--- a/apps/staking/app/stake/OpenNodes.tsx
+++ b/apps/staking/app/stake/OpenNodes.tsx
@@ -7,7 +7,7 @@ import {
 import { ErrorMessage } from '@/components/ErrorMessage';
 import { NodesListSkeleton } from '@/components/NodesListModule';
 import { OpenNodeCard } from '@/components/OpenNodeCard';
-import { useNetworkStatus } from '@/components/StatusBar';
+import { useStatusBarVisible } from '@/components/StatusBar';
 import { useCurrentActor } from '@/hooks/useCurrentActor';
 import { useOpenContributorContracts } from '@/hooks/useOpenContributorContracts';
 import { useStakes } from '@/hooks/useStakes';
@@ -22,7 +22,7 @@ import { ModuleGridInfoContent } from '@session/ui/components/ModuleGrid';
 import { Social } from '@session/ui/components/SocialLinkList';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import { type ReactNode, useEffect, useMemo } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import { usePreferences } from 'usepref';
 
 export default function OpenNodes() {
@@ -31,8 +31,8 @@ export default function OpenNodes() {
   const address = useCurrentActor();
   const { contracts, network, isFetching, refetch, isError, isLoading } =
     useOpenContributorContracts(address);
+  useStatusBarVisible({ network, isFetching, refetch });
   const { hiddenContractsWithStakes, awaitingOperatorContracts } = useStakes(address);
-  const { setNetworkStatusVisible } = useNetworkStatus({ network, isFetching, refetch });
 
   const { enabled: isStakingDisabled } = useRemoteFeatureFlagQuery(
     REMOTE_FEATURE_FLAG.DISABLE_NODE_STAKING_MULTI
@@ -61,14 +61,6 @@ export default function OpenNodes() {
       return contributor || reserved || minStakeCalculated > 0n || maxStakeCalculated > 0n;
     });
   }, [contracts, address]);
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On mount
-  useEffect(() => {
-    setNetworkStatusVisible(true);
-    return () => {
-      setNetworkStatusVisible(false);
-    };
-  }, []);
 
   return isStakingDisabled ? (
     <StakingDisabled />

--- a/apps/staking/app/stake/[address]/SubmitContributeFunds.tsx
+++ b/apps/staking/app/stake/[address]/SubmitContributeFunds.tsx
@@ -80,21 +80,21 @@ export function SubmitContributeFunds({
     resetContributeStake();
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On simulate status change
+  // biome-ignore lint/correctness/useExhaustiveDependencies(contributeStake): On simulate status change
   useEffect(() => {
     if (!isContributeStakeEnabled) {
       contributeStake();
     }
   }, [isContributeStakeEnabled]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On error
+  // biome-ignore lint/correctness/useExhaustiveDependencies(handleError): On error
   useEffect(() => {
     if (isError) {
       handleError();
     }
   }, [isError]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On success
+  // biome-ignore lint/correctness/useExhaustiveDependencies(refetch): On success
   useEffect(() => {
     if (contributeFundsStatus === PROGRESS_STATUS.SUCCESS) {
       refetch();

--- a/apps/staking/app/stake/[address]/SubmitContributeFundsVesting.tsx
+++ b/apps/staking/app/stake/[address]/SubmitContributeFundsVesting.tsx
@@ -8,6 +8,7 @@ import Typography from '@session/ui/components/Typography';
 import { cn } from '@session/ui/lib/utils';
 import { PROGRESS_STATUS, Progress } from '@session/ui/motion/progress';
 import { Button } from '@session/ui/ui/button';
+import { useMount } from '@session/util-react/hooks/useMount';
 import { useTranslations } from 'next-intl';
 import { type Dispatch, type SetStateAction, useEffect } from 'react';
 
@@ -72,20 +73,19 @@ export function SubmitContributeFundsVesting({
     resetContributeStake();
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On simulate status change
-  useEffect(() => {
+  useMount(() => {
     if (!stakingParams.contractAddress) throw new Error('Contract address is not defined');
     contributeStake(stakingParams.contractAddress);
-  }, []);
+  });
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On error
+  // biome-ignore lint/correctness/useExhaustiveDependencies(handleError): On error
   useEffect(() => {
     if (isError) {
       handleError();
     }
   }, [isError]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On success
+  // biome-ignore lint/correctness/useExhaustiveDependencies(refetch): On success
   useEffect(() => {
     if (contributeFundsStatus === PROGRESS_STATUS.SUCCESS) {
       refetch();

--- a/apps/staking/app/stake/[address]/SubmitRemoveFunds.tsx
+++ b/apps/staking/app/stake/[address]/SubmitRemoveFunds.tsx
@@ -85,21 +85,21 @@ export function SubmitRemoveFunds({
     resetContract();
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On simulate status change
+  // biome-ignore lint/correctness/useExhaustiveDependencies(withdrawContribution): On simulate status change
   useEffect(() => {
     if (!simulateEnabled) {
       withdrawContribution();
     }
   }, [simulateEnabled]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On error
+  // biome-ignore lint/correctness/useExhaustiveDependencies(handleError): On error
   useEffect(() => {
     if (isError) {
       handleError();
     }
   }, [isError]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On success
+  // biome-ignore lint/correctness/useExhaustiveDependencies(refetch): On success
   useEffect(() => {
     if (status === PROGRESS_STATUS.SUCCESS) {
       refetch();

--- a/apps/staking/components/DevSheet.tsx
+++ b/apps/staking/components/DevSheet.tsx
@@ -237,7 +237,7 @@ function ContractActions() {
     approveWrite();
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Don't need to worry about refetch changing
+  // biome-ignore lint/correctness/useExhaustiveDependencies(refetch): Don't need to worry about refetch changing
   useEffect(() => {
     if (status === 'success') void refetch();
   }, [status]);

--- a/apps/staking/components/StakedNodeCard.tsx
+++ b/apps/staking/components/StakedNodeCard.tsx
@@ -23,8 +23,12 @@ import { useStakes } from '@/hooks/useStakes';
 import { SESSION_NODE, SESSION_NODE_TIME, SESSION_NODE_TIME_STATIC } from '@/lib/constants';
 import { FEATURE_FLAG } from '@/lib/feature-flags';
 import { useFeatureFlag } from '@/lib/feature-flags-client';
-import { formatLocalizedTimeFromSeconds } from '@/lib/locale-client';
-import { formatNumber, formatPercentage, useFormatDate } from '@/lib/locale-client';
+import {
+  formatLocalizedTimeFromSeconds,
+  formatNumber,
+  formatPercentage,
+  useFormatDate,
+} from '@/lib/locale-client';
 import { ButtonDataTestId, NodeCardDataTestId } from '@/testing/data-test-ids';
 import { formatSENTBigInt } from '@session/contracts/hooks/Token';
 import type { StakeContributor } from '@session/staking-api-js/schema';

--- a/apps/staking/components/StatusBar.tsx
+++ b/apps/staking/components/StatusBar.tsx
@@ -13,6 +13,7 @@ import { cn } from '@session/ui/lib/utils';
 import { Button } from '@session/ui/ui/button';
 import { useToasterHistory } from '@session/ui/ui/sonner';
 import { Tooltip } from '@session/ui/ui/tooltip';
+import { useMount } from '@session/util-react/hooks/useMount';
 import { useBlockNumber } from '@session/wallet/hooks/useBlockNumber';
 import { useTranslations } from 'next-intl';
 import { type ReactNode, createContext, useContext, useEffect, useMemo, useState } from 'react';
@@ -325,4 +326,14 @@ export function useNetworkStatus(params?: UseNetworkStatusParams) {
   }, [refetch, context.setRefetch]);
 
   return context;
+}
+
+export function useStatusBarVisible(params?: UseNetworkStatusParams) {
+  const { setNetworkStatusVisible } = useNetworkStatus(params);
+  useMount(() => {
+    setNetworkStatusVisible(true);
+    return () => {
+      setNetworkStatusVisible(false);
+    };
+  });
 }

--- a/apps/staking/components/StatusBar.tsx
+++ b/apps/staking/components/StatusBar.tsx
@@ -328,7 +328,11 @@ export function useNetworkStatus(params?: UseNetworkStatusParams) {
   return context;
 }
 
-export function useStatusBarVisible(params?: UseNetworkStatusParams) {
+/**
+ * Display the status bar while the hook is mounted
+ * @param params network status info
+ */
+export function useDisplayStatusBar(params?: UseNetworkStatusParams) {
   const { setNetworkStatusVisible } = useNetworkStatus(params);
   useMount(() => {
     setNetworkStatusVisible(true);

--- a/apps/staking/components/TOSHandler.tsx
+++ b/apps/staking/components/TOSHandler.tsx
@@ -77,7 +77,7 @@ export function TOSHandler() {
     }
   }
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Don't need to worry about setters changing
+  // biome-ignore lint/correctness/useExhaustiveDependencies(acceptTOS): Don't need to worry about setters changing
   useEffect(() => {
     if (clearAcceptTOSFlag) {
       acceptTOS(false);

--- a/apps/staking/components/Vesting/TransferOwnerDialog.tsx
+++ b/apps/staking/components/Vesting/TransferOwnerDialog.tsx
@@ -22,6 +22,7 @@ import { AlertDialogFooter } from '@session/ui/ui/alert-dialog';
 import { Button } from '@session/ui/ui/button';
 import { Form, FormField, useForm } from '@session/ui/ui/form';
 import { areHexesEqual } from '@session/util-crypto/string';
+import { useMount } from '@session/util-react/hooks/useMount';
 import { useTranslations } from 'next-intl';
 import { useEffect, useMemo, useState } from 'react';
 import { type Address, isAddress } from 'viem';
@@ -133,10 +134,9 @@ export function TransferOwnerDialog({ onSuccessCallback }: { onSuccessCallback: 
     }
   }, [contractCallStatus]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: On mount
-  useEffect(() => {
+  useMount(() => {
     estimateContractWriteFee();
-  }, []);
+  });
 
   return (
     <>

--- a/apps/staking/package.json
+++ b/apps/staking/package.json
@@ -28,6 +28,7 @@
     "@session/util-crypto": "workspace:*",
     "@session/util-js": "workspace:*",
     "@session/util-logger": "workspace:*",
+    "@session/util-react": "workspace:*",
     "@session/wallet": "workspace:*",
     "@session/testing": "workspace:*",
     "@tanstack/react-query": "5.61.5",

--- a/apps/staking/providers/vesting-provider.tsx
+++ b/apps/staking/providers/vesting-provider.tsx
@@ -92,7 +92,10 @@ export default function VestingProvider({ children }: { children: ReactNode }) {
     [pathname, router]
   );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Don't re-trigger when pathname changes or pref changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies(pathname.startsWith): Don't re-trigger when pathname changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies(router.push): Don't re-trigger when router changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies(getItem): Don't re-trigger getItem changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies(skipped): Don't re-trigger when skip changes
   useEffect(() => {
     if (stakesLoaded) {
       if (

--- a/packages/util-react/README.md
+++ b/packages/util-react/README.md
@@ -1,0 +1,7 @@
+# @session/util-react
+
+This package is a react utility library for common functions.
+
+## Getting Started
+
+You can follow the generic instructions in the root [README.md](../../README.md#getting-started) to get started.

--- a/packages/util-react/hooks/useConditional.ts
+++ b/packages/util-react/hooks/useConditional.ts
@@ -1,0 +1,14 @@
+import { type DependencyList, useEffect } from 'react';
+
+/**
+ * Executes an effect if all dependencies are truthy
+ * @param callback The effect callback
+ * @param conditions The condition dependency array
+ */
+export const useConditional = (callback: () => void, conditions: DependencyList) =>
+  // biome-ignore lint/correctness/useExhaustiveDependencies: callback and conditions array have to be constant
+  useEffect(() => {
+    if (conditions.every((condition) => !!condition)) {
+      return callback;
+    }
+  }, conditions);

--- a/packages/util-react/hooks/useMount.ts
+++ b/packages/util-react/hooks/useMount.ts
@@ -1,0 +1,8 @@
+import { type EffectCallback, useEffect } from 'react';
+
+/**
+ * Executes the effect on component mount.
+ * @note Under the hood this is just `useEffect(()=> func(),[])`
+ * @param effect The effect callback
+ */
+export const useMount = (effect: EffectCallback) => useEffect(effect, []);

--- a/packages/util-react/package.json
+++ b/packages/util-react/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@session/util-react",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    "./*": "./*.ts",
+    "./hooks/*": "./hooks/*.ts"
+  },
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "lint": "biome lint",
+    "lint:fix": "biome lint --write",
+    "format": "biome format --write",
+    "check": "biome check",
+    "check:fix": "biome check --write"
+  },
+  "devDependencies": {
+    "@session/typescript-config": "workspace:*",
+    "@types/react": "19.0.10",
+    "@types/react-dom": "19.0.4"
+  },
+  "engines": {
+    "node": ">=22",
+    "pnpm": ">=10",
+    "yarn": "use pnpm",
+    "npm": "use pnpm"
+  }
+}

--- a/packages/util-react/tsconfig.json
+++ b/packages/util-react/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@session/typescript-config/react-library.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist"
+  },
+  "include": ["./**/**.ts", "tests/**/**.ts", "jest.config.js"],
+  "exclude": ["node_modules", "turbo", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       '@session/util-logger':
         specifier: workspace:*
         version: link:../../packages/util-logger
+      '@session/util-react':
+        specifier: workspace:*
+        version: link:../../packages/util-react
       '@session/wallet':
         specifier: workspace:*
         version: link:../../packages/wallet
@@ -400,7 +403,7 @@ importers:
         version: 5.1.1(@sanity/client@6.22.0)(react@19.0.0)
       '@sanity/preview-url-secret':
         specifier: ^1.6.21
-        version: 1.6.21(@sanity/client@6.22.0(debug@4.3.7))
+        version: 1.6.21(@sanity/client@6.22.0)
       '@sanity/vision':
         specifier: ^3.58.0
         version: 3.58.0(@babel/runtime@7.26.0)(@codemirror/lint@6.8.2)(@codemirror/theme-one-dark@6.1.2)(@lezer/common@1.2.1)(codemirror@6.0.1(@lezer/common@1.2.1))(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
@@ -641,6 +644,18 @@ importers:
       '@session/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+
+  packages/util-react:
+    devDependencies:
+      '@session/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/react':
+        specifier: 19.0.11
+        version: 19.0.11
+      '@types/react-dom':
+        specifier: 19.0.4
+        version: 19.0.4(@types/react@19.0.11)
 
   packages/wallet:
     dependencies:
@@ -12102,12 +12117,12 @@ snapshots:
       - react-is
       - styled-components
 
-  '@portabletext/editor@1.1.1(@sanity/block-tools@3.58.0(debug@4.3.7))(@sanity/schema@3.58.0(debug@4.3.7))(@sanity/types@3.58.0(debug@4.3.7))(@sanity/util@3.58.0(debug@4.3.7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@portabletext/editor@1.1.1(@sanity/block-tools@3.58.0(debug@4.3.7))(@sanity/schema@3.58.0(debug@4.3.7))(@sanity/types@3.58.0)(@sanity/util@3.58.0(debug@4.3.7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@portabletext/patches': 1.1.0
       '@sanity/block-tools': 3.58.0(debug@4.3.7)
       '@sanity/schema': 3.58.0(debug@4.3.7)
-      '@sanity/types': 3.58.0
+      '@sanity/types': 3.58.0(debug@4.3.7)
       '@sanity/util': 3.58.0(debug@4.3.7)
       debug: 4.3.7
       is-hotkey-esm: 1.0.0
@@ -13538,7 +13553,7 @@ snapshots:
 
   '@sanity/block-tools@3.58.0(debug@4.3.7)':
     dependencies:
-      '@sanity/types': 3.58.0
+      '@sanity/types': 3.58.0(debug@4.3.7)
       '@types/react': 19.0.11
       get-random-values-esm: 1.0.2
       lodash: 4.17.21
@@ -13686,10 +13701,10 @@ snapshots:
       react-copy-to-clipboard: 5.1.0(react@19.0.0)
       react-dom: 19.0.0(react@19.0.0)
 
-  '@sanity/insert-menu@1.0.9(@sanity/types@3.58.0(debug@4.3.7))(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@sanity/insert-menu@1.0.9(@sanity/types@3.58.0)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@sanity/icons': 3.4.0(react@19.0.0)
-      '@sanity/types': 3.58.0
+      '@sanity/types': 3.58.0(debug@4.3.7)
       '@sanity/ui': 2.8.9(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       lodash.startcase: 4.4.0
       react: 19.0.0
@@ -13751,7 +13766,7 @@ snapshots:
     dependencies:
       '@sanity/client': 6.22.0
       '@sanity/icons': 3.4.0(react@19.0.0)
-      '@sanity/preview-url-secret': 1.6.21(@sanity/client@6.22.0(debug@4.3.7))
+      '@sanity/preview-url-secret': 1.6.21(@sanity/client@6.22.0)
       '@sanity/ui': 2.8.9(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@sanity/uuid': 3.0.2
       '@types/lodash.isequal': 4.5.8
@@ -13783,7 +13798,7 @@ snapshots:
     optionalDependencies:
       react: 19.0.0
 
-  '@sanity/preview-url-secret@1.6.21(@sanity/client@6.22.0(debug@4.3.7))':
+  '@sanity/preview-url-secret@1.6.21(@sanity/client@6.22.0)':
     dependencies:
       '@sanity/client': 6.22.0
       '@sanity/uuid': 3.0.2
@@ -13791,7 +13806,7 @@ snapshots:
   '@sanity/schema@3.58.0(debug@4.3.7)':
     dependencies:
       '@sanity/generate-help-url': 3.0.0
-      '@sanity/types': 3.58.0
+      '@sanity/types': 3.58.0(debug@4.3.7)
       arrify: 1.0.1
       groq-js: 1.13.0
       humanize-list: 1.0.1
@@ -13827,16 +13842,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/types@3.58.0':
-    dependencies:
-      '@sanity/client': 6.22.0
-      '@types/react': 19.0.11
-    transitivePeerDependencies:
-      - debug
-
   '@sanity/types@3.58.0(debug@4.3.7)':
     dependencies:
-      '@sanity/client': 6.22.0(debug@4.3.7)
+      '@sanity/client': 6.22.0
       '@types/react': 19.0.11
     transitivePeerDependencies:
       - debug
@@ -13868,7 +13876,7 @@ snapshots:
   '@sanity/util@3.58.0(debug@4.3.7)':
     dependencies:
       '@sanity/client': 6.22.0
-      '@sanity/types': 3.58.0
+      '@sanity/types': 3.58.0(debug@4.3.7)
       get-random-values-esm: 1.0.2
       moment: 2.30.1
       rxjs: 7.8.1
@@ -13915,7 +13923,7 @@ snapshots:
 
   '@sanity/visual-editing@2.1.10(@sanity/client@6.22.0)(next@15.2.3(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@sanity/preview-url-secret': 1.6.21(@sanity/client@6.22.0(debug@4.3.7))
+      '@sanity/preview-url-secret': 1.6.21(@sanity/client@6.22.0)
       '@vercel/stega': 0.1.2
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
@@ -15111,7 +15119,7 @@ snapshots:
       clsx: 2.1.1
       cmdk: 1.0.4(@types/react-dom@19.0.4(@types/react@19.0.11))(@types/react@19.0.11)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
       lucide-react: 0.376.0(react@19.0.0-rc-66855b96-20241106)
-      next: 15.0.4(@babel/core@7.26.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0))(react@19.0.0-rc-66855b96-20241106)
+      next: 15.0.4(@babel/core@7.26.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
       next-themes: 0.4.6(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
       react: 19.0.0-rc-66855b96-20241106
       react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
@@ -18975,7 +18983,7 @@ snapshots:
       '@sanity/client': 6.22.0
       '@sanity/icons': 3.4.0(react@19.0.0)
       '@sanity/preview-kit': 5.1.1(@sanity/client@6.22.0)(react@19.0.0)
-      '@sanity/types': 3.58.0
+      '@sanity/types': 3.58.0(debug@4.3.7)
       '@sanity/ui': 2.8.9(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@sanity/visual-editing': 2.1.10(@sanity/client@6.22.0)(next@15.2.3(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       groq: 3.58.0
@@ -19000,7 +19008,7 @@ snapshots:
       react: 19.0.0-rc-66855b96-20241106
       react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
 
-  next@15.0.4(@babel/core@7.26.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0))(react@19.0.0-rc-66855b96-20241106):
+  next@15.0.4(@babel/core@7.26.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0):
     dependencies:
       '@next/env': 15.0.4
       '@swc/counter': 0.1.3
@@ -19008,9 +19016,9 @@ snapshots:
       busboy: 1.6.0
       caniuse-lite: 1.0.30001684
       postcss: 8.4.31
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.0.0
       react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
-      styled-jsx: 5.1.6(@babel/core@7.26.0)(react@19.0.0-rc-66855b96-20241106)
+      styled-jsx: 5.1.6(@babel/core@7.26.0)(react@19.0.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.0.4
       '@next/swc-darwin-x64': 15.0.4
@@ -19025,7 +19033,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.0.4(@babel/core@7.26.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0):
+  next@15.0.4(@babel/core@7.26.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106):
     dependencies:
       '@next/env': 15.0.4
       '@swc/counter': 0.1.3
@@ -19033,9 +19041,9 @@ snapshots:
       busboy: 1.6.0
       caniuse-lite: 1.0.30001684
       postcss: 8.4.31
-      react: 19.0.0
+      react: 19.0.0-rc-66855b96-20241106
       react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
-      styled-jsx: 5.1.6(@babel/core@7.26.0)(react@19.0.0)
+      styled-jsx: 5.1.6(@babel/core@7.26.0)(react@19.0.0-rc-66855b96-20241106)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.0.4
       '@next/swc-darwin-x64': 15.0.4
@@ -20261,7 +20269,7 @@ snapshots:
     dependencies:
       '@sanity/icons': 2.11.8(react@19.0.0)
       '@sanity/incompatible-plugin': 1.0.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@sanity/preview-url-secret': 1.6.21(@sanity/client@6.22.0(debug@4.3.7))
+      '@sanity/preview-url-secret': 1.6.21(@sanity/client@6.22.0)
       '@sanity/ui': 2.8.9(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       framer-motion: 11.0.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
@@ -20301,14 +20309,14 @@ snapshots:
       '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       '@dnd-kit/utilities': 3.2.2(react@19.0.0)
       '@juggle/resize-observer': 3.4.0
-      '@portabletext/editor': 1.1.1(@sanity/block-tools@3.58.0(debug@4.3.7))(@sanity/schema@3.58.0(debug@4.3.7))(@sanity/types@3.58.0(debug@4.3.7))(@sanity/util@3.58.0(debug@4.3.7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      '@portabletext/editor': 1.1.1(@sanity/block-tools@3.58.0(debug@4.3.7))(@sanity/schema@3.58.0(debug@4.3.7))(@sanity/types@3.58.0)(@sanity/util@3.58.0(debug@4.3.7))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@portabletext/react': 3.1.0(react@19.0.0)
       '@rexxars/react-json-inspector': 8.0.1(react@19.0.0)
       '@sanity/asset-utils': 1.3.2
       '@sanity/bifur-client': 0.4.1
       '@sanity/block-tools': 3.58.0(debug@4.3.7)
       '@sanity/cli': 3.58.0(react@19.0.0)
-      '@sanity/client': 6.22.0
+      '@sanity/client': 6.22.0(debug@4.3.7)
       '@sanity/color': 3.0.6
       '@sanity/diff': 3.58.0
       '@sanity/diff-match-patch': 3.1.1
@@ -20317,14 +20325,14 @@ snapshots:
       '@sanity/icons': 3.4.0(react@19.0.0)
       '@sanity/image-url': 1.0.2
       '@sanity/import': 3.37.5
-      '@sanity/insert-menu': 1.0.9(@sanity/types@3.58.0(debug@4.3.7))(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      '@sanity/insert-menu': 1.0.9(@sanity/types@3.58.0)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@sanity/logos': 2.1.13(@sanity/color@3.0.6)(react@19.0.0)
       '@sanity/migrate': 3.58.0
       '@sanity/mutator': 3.58.0
       '@sanity/presentation': 1.16.5(@sanity/client@6.22.0)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@sanity/schema': 3.58.0(debug@4.3.7)
       '@sanity/telemetry': 0.7.9(react@19.0.0)
-      '@sanity/types': 3.58.0
+      '@sanity/types': 3.58.0(debug@4.3.7)
       '@sanity/ui': 2.8.9(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@sanity/util': 3.58.0(debug@4.3.7)
       '@sanity/uuid': 3.0.2


### PR DESCRIPTION
This pull request introduces several changes across multiple files to improve code consistency and simplify lifecycle management by replacing `useEffect` with a custom `useMount` hook. It also adds a new utility library, `@session/util-react`, to the project. Below is a summary of the most important changes:

### New Utility Library
* Added `@session/util-react` to the repository, which includes React-specific utilities such as the `useMount` hook. (`README.md`, [README.mdR46](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46))

### Refactoring: Replacing `useEffect` with `useMount`
* Replaced instances of `useEffect` for on-mount logic with the `useMount` hook across various components and modules to improve readability and reduce boilerplate code:
  - [`StakedNodesModule.tsx`](diffhunk://#diff-10c4d8a825f9600ded54ab2fe199ff71131c6229eddd4cbda55049a4df2f1415L10-R10): Updated to use `useStatusBarVisible` and removed on-mount `useEffect` logic. [[1]](diffhunk://#diff-10c4d8a825f9600ded54ab2fe199ff71131c6229eddd4cbda55049a4df2f1415L10-R10) [[2]](diffhunk://#diff-10c4d8a825f9600ded54ab2fe199ff71131c6229eddd4cbda55049a4df2f1415L51-R50)
  - [`NodeRegistrations.tsx`](diffhunk://#diff-e9e56711974be9e563f93ca62bbed0646d8a49a52012531ecc0ebda03ff34b01L75-R83): Refactored on-mount `useEffect` to use `useMount`.
  - `Registration.tsx`: Replaced on-mount `useEffect` with `useMount` for balance visibility logic. ([apps/staking/app/register/[nodeId]/Registration.tsxL575-R578](diffhunk://#diff-646e8564ececaa14558d46c70ec55a6c1a544967a9978d7c97d7d701b9e86bc6L575-R578))
  - Multiple tabs in the `multi` and `solo` registration flows (e.g., `AutoActivateTab`, `OperatorFeeTab`, `RewardsAddressInputMultiTab`, etc.) were updated to use `useMount` for setting and clearing callbacks. ([apps/staking/app/register/[nodeId]/multi/AutoActivateTab.tsxL31-R35](diffhunk://#diff-2a645adc2300cd83c334cec9d0a67f8ca6c41c4e348590b9f856c3b2a08cfd78L31-R35), [apps/staking/app/register/[nodeId]/multi/OperatorFeeTab.tsxL42-R46](diffhunk://#diff-07382fcc126c217445048c07b1ae47385d26293ff891e7d9cbf174f6ccfc8730L42-R46), [apps/staking/app/register/[nodeId]/multi/RewardsAddressInputMultiTab.tsxL38-R42](diffhunk://#diff-4b1bd21325462c1c22cbbb4fd1b7e6b0649ec241ebccdcd4940eac68231f362cL38-R42), [apps/staking/app/register/[nodeId]/solo/RewardsAddressInputSoloTab.tsxL22-R26](diffhunk://#diff-cd8b4067eb9c0260760cd289774819512fef473af2ab9a1d6774aa5e90804c59L22-R26), [apps/staking/app/register/[nodeId]/multi/StakeAmountTab.tsxL66-R70](diffhunk://#diff-533fdda5278fae1e73cf7289841d230e31dd8b0448ca10fa65580f3fe2bc8d93L66-R70), [apps/staking/app/register/[nodeId]/shared/AlreadyRegisteredRunningTab.tsxL37-R39](diffhunk://#diff-efffb97104970ba32e88ee97f4b72e15c0195800c49f31ab6126c3712ab50effL37-R39), [apps/staking/app/register/[nodeId]/solo/useSubmitSolo.tsxL78-R85](diffhunk://#diff-afef7326c4d68e918a43ea2b56a3dcc33550b6c2b566efc6b473f8d1d8f89a83L78-R85))

### Code Cleanup
* Removed unused `useEffect` imports from files where it was replaced with `useMount`. [[1]](diffhunk://#diff-10c4d8a825f9600ded54ab2fe199ff71131c6229eddd4cbda55049a4df2f1415L31) [apps/staking/app/register/[nodeId]/Registration.tsxL79](diffhunk://#diff-646e8564ececaa14558d46c70ec55a6c1a544967a9978d7c97d7d701b9e86bc6L79), [apps/staking/app/register/[nodeId]/multi/AutoActivateTab.tsxR8-R10](diffhunk://#diff-2a645adc2300cd83c334cec9d0a67f8ca6c41c4e348590b9f856c3b2a08cfd78R8-R10), [apps/staking/app/register/[nodeId]/multi/ReserveSlotsInputTab.tsxL262-R266](diffhunk://#diff-a60bbf114849f2e89cb847243944b72e2e04e805aee66ad6389706b4dee4e24aL262-R266), [apps/staking/app/register/[nodeId]/multi/RewardsAddressInputMultiTab.tsxR11-R13](diffhunk://#diff-4b1bd21325462c1c22cbbb4fd1b7e6b0649ec241ebccdcd4940eac68231f362cR11-R13), [apps/staking/app/register/[nodeId]/solo/RewardsAddressInputSoloTab.tsxR7-R9](diffhunk://#diff-cd8b4067eb9c0260760cd289774819512fef473af2ab9a1d6774aa5e90804c59R7-R9), [apps/staking/app/register/[nodeId]/solo/useSubmitSolo.tsxL10-R12](diffhunk://#diff-afef7326c4d68e918a43ea2b56a3dcc33550b6c2b566efc6b473f8d1d8f89a83L10-R12), [[2]](diffhunk://#diff-8de8443bbbefbf69839869a69ea6f999db31c2d922c3836657123f0755d0186cL25-R25)

### Status Bar Visibility
* Updated components to use the new `useStatusBarVisible` hook instead of `useNetworkStatus` for managing the visibility of the network status bar:
  - `StakedNodesModule.tsx` and `OpenNodes.tsx`. [[1]](diffhunk://#diff-10c4d8a825f9600ded54ab2fe199ff71131c6229eddd4cbda55049a4df2f1415L10-R10) [[2]](diffhunk://#diff-8de8443bbbefbf69839869a69ea6f999db31c2d922c3836657123f0755d0186cL10-R10) [[3]](diffhunk://#diff-8de8443bbbefbf69839869a69ea6f999db31c2d922c3836657123f0755d0186cR34-L35)

These changes enhance maintainability and consistency while reducing repetitive code patterns.