### PR TITLE
Chore: default auto refresh backend

### DIFF
--- a/apps/staking/app/mystakes/modules/PriceModule.tsx
+++ b/apps/staking/app/mystakes/modules/PriceModule.tsx
@@ -27,7 +27,7 @@ const pricesSchema = z.object({
 
 const useHistoricalPriceQuery = () => {
   const { getItem } = usePreferences();
-  const autoRefresh = getItem(PREFERENCE.AUTO_REFRESH_BACKEND);
+  const autoRefresh = !getItem(PREFERENCE.DISABLE_BACKEND_AUTO_REFRESH);
   return useQuery({
     queryKey: ['prices'],
     queryFn: async () => {

--- a/apps/staking/hooks/useDailyRewards.tsx
+++ b/apps/staking/hooks/useDailyRewards.tsx
@@ -13,7 +13,7 @@ export const useDailyRewards = (params?: { addressOverride?: Address }) => {
   const { getItem } = usePreferences();
   const address = params?.addressOverride ?? connectedAddress;
 
-  const autoRefresh = !!getItem<boolean>(PREFERENCE.AUTO_REFRESH_BACKEND);
+  const autoRefresh = !getItem<boolean>(PREFERENCE.DISABLE_BACKEND_AUTO_REFRESH);
 
   const enabled = !!address;
 

--- a/apps/staking/hooks/useNetworkBalances.tsx
+++ b/apps/staking/hooks/useNetworkBalances.tsx
@@ -18,7 +18,7 @@ export const useNetworkBalances = (params?: { addressOverride?: Address }) => {
   const { getItem } = usePreferences();
   const address = params?.addressOverride ?? connectedAddress;
 
-  const autoRefresh = !!getItem<boolean>(PREFERENCE.AUTO_REFRESH_BACKEND);
+  const autoRefresh = !getItem<boolean>(PREFERENCE.DISABLE_BACKEND_AUTO_REFRESH);
 
   const enabled = !!address;
 

--- a/apps/staking/hooks/useOpenContributorContracts.tsx
+++ b/apps/staking/hooks/useOpenContributorContracts.tsx
@@ -19,7 +19,7 @@ import type { Address } from 'viem';
  */
 export function useOpenContributorContracts(overrideAddress?: Address) {
   const { getItem } = usePreferences();
-  const autoRefresh = !!getItem<boolean>(PREFERENCE.AUTO_REFRESH_BACKEND);
+  const autoRefresh = !getItem<boolean>(PREFERENCE.DISABLE_BACKEND_AUTO_REFRESH);
   const { address: connectedAddress } = useWallet();
   const address = overrideAddress ?? connectedAddress;
 

--- a/apps/staking/hooks/useStakes.tsx
+++ b/apps/staking/hooks/useStakes.tsx
@@ -25,7 +25,7 @@ export function useStakes(overrideAddress?: Address, overrideRefetchIntervalMs?:
   const address = overrideAddress ?? connectedAddress;
   const { getItem } = usePreferences();
   const enabled = !!address;
-  const autoRefresh = !!getItem<boolean>(PREFERENCE.AUTO_REFRESH_BACKEND);
+  const autoRefresh = !getItem<boolean>(PREFERENCE.DISABLE_BACKEND_AUTO_REFRESH);
 
   const { data: arbBlock } = useBlockNumber({
     query: {

--- a/apps/staking/hooks/useUnclaimedTokens.tsx
+++ b/apps/staking/hooks/useUnclaimedTokens.tsx
@@ -24,7 +24,7 @@ export const useUnclaimedTokens = (params?: { addressOverride?: Address }) => {
   const address = params?.addressOverride ?? connectedAddress;
 
   const enabled = !!address;
-  const autoRefresh = !!getItem<boolean>(PREFERENCE.AUTO_REFRESH_BACKEND);
+  const autoRefresh = !getItem<boolean>(PREFERENCE.DISABLE_BACKEND_AUTO_REFRESH);
 
   const {
     data,

--- a/apps/staking/lib/constants.ts
+++ b/apps/staking/lib/constants.ts
@@ -231,7 +231,7 @@ export enum PREFERENCE {
   SHOW_L2_HEIGHT_ON_STATUS_BAR = 'showL2HeightOnStatusBar',
   SKIP_VESTING_POPUP_ON_STARTUP = 'skipVestingPopupOnStartup',
   ANONYMIZE_UI = 'anonymizeUI',
-  AUTO_REFRESH_BACKEND = 'autoRefreshBackend',
+  DISABLE_BACKEND_AUTO_REFRESH = 'disableBackendAutoRefresh',
   OPEN_NODES_SHOW_AWAITING_OPERATOR = 'openNodesShowAwaitingOperator',
   INFO_NOTICE_DONT_SHOW_REGISTER = 'infoNoticeDontShowRegister',
   INFO_NOTICE_DONT_SHOW_STAKE = 'infoNoticeDontShowStake',
@@ -246,10 +246,10 @@ type WalletSheetSettingDetailsGenerator = Record<
 >;
 
 export const prefDetails = {
-  [PREFERENCE.AUTO_REFRESH_BACKEND]: {
-    label: 'Auto Refresh',
+  [PREFERENCE.DISABLE_BACKEND_AUTO_REFRESH]: {
+    label: 'Disable Auto Refresh',
     type: 'boolean',
-    defaultValue: true,
+    defaultValue: false,
   },
   [PREFERENCE.BACKEND_URL]: {
     label: 'Backend URL',


### PR DESCRIPTION
This pull request updates the handling of the auto-refresh feature in the staking app by replacing the `AUTO_REFRESH_BACKEND` preference with a new `DISABLE_BACKEND_AUTO_REFRESH` preference. The changes ensure a more intuitive configuration by switching from an opt-in to an opt-out approach for backend auto-refresh functionality. The most important changes are summarized below.

### Preference Update:

* Replaced the `PREFERENCE.AUTO_REFRESH_BACKEND` constant with `PREFERENCE.DISABLE_BACKEND_AUTO_REFRESH` in `apps/staking/lib/constants.ts`. Updated the label to "Disable Auto Refresh" and changed the default value from `true` to `false` to reflect the new opt-out logic. [[1]](diffhunk://#diff-578637cbc18415999d79f1fb6710ca832e54f712c43e7c8f8127d529621c6ef3L234-R234) [[2]](diffhunk://#diff-578637cbc18415999d79f1fb6710ca832e54f712c43e7c8f8127d529621c6ef3L249-R252)

### Code Adjustments:

* Updated logic across multiple files to use `!getItem(PREFERENCE.DISABLE_BACKEND_AUTO_REFRESH)` instead of `getItem(PREFERENCE.AUTO_REFRESH_BACKEND)`. This change ensures that the auto-refresh behavior aligns with the updated preference structure:
  - `PriceModule.tsx`
  - `useDailyRewards.tsx`
  - `useNetworkBalances.tsx`
  - `useOpenContributorContracts.tsx`
  - `useStakes.tsx`
  - `useUnclaimedTokens.tsx`