### PR TITLE
fix: make unstaked vesting amounts non-rounded and unlock date to use days

### DIFF
--- a/apps/staking/app/vested-stakes/modules/VestingEndTimeModule.tsx
+++ b/apps/staking/app/vested-stakes/modules/VestingEndTimeModule.tsx
@@ -8,12 +8,19 @@ import { Module, ModuleText, ModuleTitle, ModuleTooltip } from '@session/ui/comp
 import { LoadingText } from '@session/ui/components/loading-text';
 import { Tooltip } from '@session/ui/ui/tooltip';
 import { useTranslations } from 'next-intl';
+import { useMemo } from 'react';
 
 export function useVestingEndTime() {
   const contract = useActiveVestingContract();
-  const date = contract ? new Date(contract?.time_end * 1000) : null;
+  const date = useMemo(() => (contract ? new Date(contract.time_end * 1000) : null), [contract]);
   const formattedDate = useFormatDate(date, { dateStyle: 'full', timeStyle: 'long' });
-  const relativeTime = useRelativeTime(date, { addSuffix: false });
+
+  const unit = useMemo(
+    () => (date && date.getTime() - Date.now() > 24 * 60 * 60 * 1000 ? 'day' : undefined),
+    [date]
+  );
+
+  const relativeTime = useRelativeTime(date, { addSuffix: false, unit });
   const isEnded = (date?.getTime() ?? 0) < Date.now();
   return { date, formattedDate, relativeTime, isEnded };
 }

--- a/apps/staking/app/vested-stakes/modules/VestingUnstakedBalanceModule.tsx
+++ b/apps/staking/app/vested-stakes/modules/VestingUnstakedBalanceModule.tsx
@@ -4,7 +4,7 @@ import { useVestingEndTime } from '@/app/vested-stakes/modules/VestingEndTimeMod
 import { ModuleDynamicQueryText } from '@/components/ModuleDynamic';
 import type { QUERY_STATUS } from '@/lib/query';
 import { useActiveVestingContractAddress } from '@/providers/vesting-provider';
-import { addresses, isValidChainId } from '@session/contracts';
+import { SENT_DECIMALS, addresses, isValidChainId } from '@session/contracts';
 import { formatSENTBigInt } from '@session/contracts/hooks/Token';
 import { Module, ModuleTitle, ModuleTooltip } from '@session/ui/components/Module';
 import { useERC20Balance } from '@session/wallet/hooks/useERC20Balance';
@@ -25,6 +25,7 @@ export function useVestingUnstakedBalance() {
 
   return {
     formattedAmount: formatSENTBigInt(amount),
+    formattedAmountAccurate: formatSENTBigInt(amount, SENT_DECIMALS),
     amount,
     status,
     refetch,

--- a/apps/staking/components/Vesting/VestingHandler.tsx
+++ b/apps/staking/components/Vesting/VestingHandler.tsx
@@ -6,6 +6,7 @@ import { NodeCard } from '@/components/NodeCard';
 import { useVesting } from '@/providers/vesting-provider';
 import { ButtonDataTestId } from '@/testing/data-test-ids';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { SENT_DECIMALS } from '@session/contracts';
 import { formatSENTBigInt } from '@session/contracts/hooks/Token';
 import { PubKey } from '@session/ui/components/PubKey';
 import { Button } from '@session/ui/ui/button';
@@ -118,7 +119,7 @@ export function VestingHandler({
                           <NodeItem>
                             <NodeItemLabel>{dictCard('balance')}</NodeItemLabel>
                             <NodeItemValue>
-                              {formatSENTBigInt(contract.initial_amount)}
+                              {formatSENTBigInt(contract.initial_amount, SENT_DECIMALS)}
                             </NodeItemValue>
                           </NodeItem>
                         </FormLabel>

--- a/apps/staking/components/Vesting/VestingInfo.tsx
+++ b/apps/staking/components/Vesting/VestingInfo.tsx
@@ -6,6 +6,7 @@ import { useNetworkBalances } from '@/hooks/useNetworkBalances';
 import { DYNAMIC_MODULE } from '@/lib/constants';
 import { useActiveVestingContract } from '@/providers/vesting-provider';
 import { ButtonDataTestId } from '@/testing/data-test-ids';
+import { SENT_DECIMALS } from '@session/contracts';
 import { formatSENTBigInt } from '@session/contracts/hooks/Token';
 import { EditButton } from '@session/ui/components/EditButton';
 import { PubKey } from '@session/ui/components/PubKey';
@@ -15,7 +16,7 @@ import { useTranslations } from 'next-intl';
 export function useVestingInitialBalance() {
   const vestingContract = useActiveVestingContract();
   const balance = vestingContract?.initial_amount ?? 0n;
-  const formattedBalance = formatSENTBigInt(balance);
+  const formattedBalance = formatSENTBigInt(balance, SENT_DECIMALS);
   return { balance, formattedBalance };
 }
 
@@ -39,7 +40,7 @@ export function VestingInfo({
   const address = vestingContract?.address;
 
   const { totalStakedFormatted } = useTotalStaked(vestingContract?.address);
-  const { formattedAmount: vestingUnstakedBalance } = useVestingUnstakedBalance();
+  const { formattedAmountAccurate: vestingUnstakedBalance } = useVestingUnstakedBalance();
   const { unclaimed } = useNetworkBalances({ addressOverride: address });
   const formattedUnclaimedRewardsAmount = formatSENTBigInt(
     unclaimed,


### PR DESCRIPTION
This pull request introduces optimizations and enhancements to the `apps/staking` modules and components, primarily focusing on improving performance with memoization and ensuring consistent precision in formatting token balances. The most important changes are grouped below by theme.

### Performance Optimizations:
* Updated the `useVestingEndTime` hook to use `useMemo` for computing the `date` and `unit` values, reducing unnecessary recalculations.

### Token Balance Precision:
* Introduced the `SENT_DECIMALS` constant in multiple components and updated the `formatSENTBigInt` calls to include it, ensuring token balances are formatted with consistent precision:
  - `VestingUnstakedBalanceModule.tsx` now includes `formattedAmountAccurate` for higher precision.
  - `VestingHandler.tsx` uses `SENT_DECIMALS` for formatting `contract.initial_amount`.
  - `VestingInfo.tsx` applies `SENT_DECIMALS` for `initial_amount` and updates the unstaked balance to use `formattedAmountAccurate`. [[1]](diffhunk://#diff-656be4bad4429d312f97bd76803086a1d27a51ad4f3523e856d5a5980533a565L18-R19) [[2]](diffhunk://#diff-656be4bad4429d312f97bd76803086a1d27a51ad4f3523e856d5a5980533a565L42-R43)… days