### PR TITLE
chore: update arbitrum bridge link with token address

### DIFF
--- a/apps/staking/next.config.mjs
+++ b/apps/staking/next.config.mjs
@@ -76,13 +76,13 @@ const nextConfig = {
       {
         source: '/bridge/arbitrum',
         destination:
-          `https://bridge.arbitrum.io/?destinationChain=arbitrum-${isTestnet ? 'sepolia' : 'one'}&sourceChain=${isTestnet ? 'sepolia' : 'ethereum'}`,
+          `https://bridge.arbitrum.io/?destinationChain=arbitrum-${isTestnet ? 'sepolia' : 'one'}&sourceChain=${isTestnet ? 'sepolia' : 'ethereum'}&token=0x10ea9e5303670331bdddfa66a4cea47dae4fcf3b`,
         permanent: false,
       },
       {
         source: '/bridge/ethereum',
         destination:
-          `https://bridge.arbitrum.io/?destinationChain=${isTestnet ? 'sepolia':'ethereum'}&sourceChain=arbitrum-${isTestnet ? 'sepolia' : 'one'}`,
+          `https://bridge.arbitrum.io/?destinationChain=${isTestnet ? 'sepolia':'ethereum'}&sourceChain=arbitrum-${isTestnet ? 'sepolia' : 'one'}&token=0x10ea9e5303670331bdddfa66a4cea47dae4fcf3b`,
         permanent: false,
       },
       {


### PR DESCRIPTION
This pull request updates the URL redirections in the `next.config.mjs` file for the staking application to include a specific token parameter in the query string.

### URL Redirection Updates:
* Modified the redirection for `/bridge/arbitrum` to append the `token=0x10ea9e5303670331bdddfa66a4cea47dae4fcf3b` parameter to the destination URL.
* Modified the redirection for `/bridge/ethereum` to append the `token=0x10ea9e5303670331bdddfa66a4cea47dae4fcf3b` parameter to the destination URL.