### PR TITLE
fix: add bigint replacer to maths json stringify

### DIFF
--- a/apps/staking/tests/maths.spec.ts
+++ b/apps/staking/tests/maths.spec.ts
@@ -1,6 +1,8 @@
 import { ServiceNodeContributionAbi } from '@session/contracts/abis';
+import { jsonBigIntReplacer } from '@session/util-js/bigint';
 import { http, type Address, createPublicClient } from 'viem';
 import { arbitrumSepolia } from 'viem/chains';
+
 import { parseContributorDetails } from '../lib/maths';
 
 type Contributor = {
@@ -21,6 +23,8 @@ function createContributor(amount: bigint): Contributor {
     amount,
   };
 }
+
+const jsonStringify = (value:unknown) => JSON.stringify(value, jsonBigIntReplacer);
 
 const operatorContributorAmounts = [
   6250_000000000n,
@@ -207,7 +211,7 @@ describe(`parseContributorDetails fuzzing (fuzzAmount: ${fuzzAmount}`, () => {
       minStake = res.minStake;
       totalStaked = res.totalStaked;
     } catch (e) {
-      throw new Error(`Failed to get min stake for ${JSON.stringify(contributors)} ${e}`);
+      throw new Error(`Failed to get min stake for ${jsonStringify(contributors)} ${e}`);
     }
 
     const contribTest = new Promise((resolve) => {


### PR DESCRIPTION
This pull request introduces a utility function for JSON stringification with BigInt support and integrates it into existing error handling in the `apps/staking/tests/maths.spec.ts` file. The changes improve the handling of BigInt values during debugging and error reporting.

### Utility Function Addition:
* Added `jsonBigIntReplacer` import from `@session/util-js/bigint`.
* Introduced a `jsonStringify` helper function that uses `JSON.stringify` with `jsonBigIntReplacer` to handle BigInt values.

### Error Handling Improvement:
* Updated error message in the `parseContributorDetails fuzzing` test to use `jsonStringify` for better representation of BigInt values in the `contributors` object.