### PR TITLE
feat: add optional badges to tiles and allow for asc key files

### DIFF
--- a/apps/foundation/app/(Site)/[slug]/page.tsx
+++ b/apps/foundation/app/(Site)/[slug]/page.tsx
@@ -114,6 +114,8 @@ export default async function UniversalPage({ params }: PageProps) {
             clickToDownloadAria: fileDictionary('clickToDownloadAria'),
             openPdfInNewTab: fileDictionary('openPdfInNewTab'),
             openPdfInNewTabAria: fileDictionary('openPdfInNewTabAria'),
+            openFileInNewTab: fileDictionary('openFileInNewTab'),
+            openFileInNewTabAria: fileDictionary('openFileInNewTabAria'),
           }}
         />
       );

--- a/apps/foundation/locales/en.json
+++ b/apps/foundation/locales/en.json
@@ -26,6 +26,8 @@
     "clickToDownload": "Click to download",
     "clickToDownloadAria": "Click to download file",
     "openPdfInNewTab": "Open PDF in new tab",
-    "openPdfInNewTabAria": "Open PDF in new tab"
+    "openPdfInNewTabAria": "Open PDF in new tab",
+    "openFileInNewTab": "Open File in new tab",
+    "openFileInNewTabAria": "Open File in new tab"
   }
 }

--- a/packages/sanity-cms/components/SanityAsc.tsx
+++ b/packages/sanity-cms/components/SanityAsc.tsx
@@ -1,0 +1,28 @@
+import { DownloadFileButton } from './SanityFileDownload';
+
+export type SanityAscProps = {
+  src: string;
+  url: URL;
+  strings: {
+    clickToDownload: string;
+    clickToDownloadAria: string;
+  };
+};
+
+export default function SanityAsc({ src, url, strings }: SanityAscProps) {
+  if (!url || !src) return null;
+
+  return (
+    <main className="flex h-full min-h-screen w-full max-w-3xl flex-col items-start justify-start gap-4">
+      <DownloadFileButton href={url.href} ariaLabel={strings.clickToDownloadAria}>
+        {strings.clickToDownload}
+      </DownloadFileButton>
+      <iframe
+        src={src}
+        className="h-full min-h-screen w-full"
+        style={{ border: 'none' }}
+        title="ASC"
+      />
+    </main>
+  );
+}

--- a/packages/sanity-cms/components/SanityFileDownload.tsx
+++ b/packages/sanity-cms/components/SanityFileDownload.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import SanityPdf from './SanityPdf';
-import { useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { cleanSanityString } from '../lib/string';
+import SanityAsc from './SanityAsc';
 
 type FileDownloadProps = {
   fileName: string;
@@ -14,8 +15,33 @@ type FileDownloadProps = {
     clickToDownloadAria: string;
     openPdfInNewTab: string;
     openPdfInNewTabAria: string;
+    openFileInNewTab: string;
+    openFileInNewTabAria: string;
   };
 };
+
+type DownloadFileButtonProps = {
+  href: string;
+  ariaLabel: string;
+  children: ReactNode;
+};
+
+export function DownloadFileButton({ href, ariaLabel, children }: DownloadFileButtonProps) {
+  return (
+    <a
+      href={href}
+      className="group"
+      target="_blank"
+      rel="noopener noreferrer"
+      download
+      aria-label={ariaLabel}
+    >
+      <button className="group-hover:decoration-session-green hover:decoration-session-green decoration-session-black mt-1 w-max text-sm underline group-hover:underline">
+        {children}
+      </button>
+    </a>
+  );
+}
 
 export default function FileDownload({ fileName, src, strings }: FileDownloadProps) {
   const [downloaded, setDownloaded] = useState(false);
@@ -26,8 +52,12 @@ export default function FileDownload({ fileName, src, strings }: FileDownloadPro
   const srcWithParams = new URL(src);
   srcWithParams.searchParams.set('dl', name);
 
-  if (src.includes('.pdf')) {
+  if (src.endsWith('.pdf')) {
     return <SanityPdf src={src} url={srcWithParams} strings={strings} />;
+  }
+
+  if (src.endsWith('.asc')) {
+    return <SanityAsc src={src} url={srcWithParams} strings={strings} />;
   }
 
   // Download file on mount
@@ -41,18 +71,9 @@ export default function FileDownload({ fileName, src, strings }: FileDownloadPro
   return (
     <div className="my-12 flex flex-col items-center justify-center gap-2">
       <p className="text-center text-sm">{strings.fetching.replace('{name}', fileName)}</p>
-      <a
-        href={srcWithParams.href}
-        className="group"
-        target="_blank"
-        rel="noopener noreferrer"
-        download
-        aria-label={strings.clickToDownloadAria}
-      >
-        <button className="group-hover:decoration-session-green hover:decoration-session-green decoration-session-black mt-1 w-max text-sm underline group-hover:underline">
-          {strings.clickToDownload}
-        </button>
-      </a>
+      <DownloadFileButton href={srcWithParams.href} ariaLabel={strings.clickToDownloadAria}>
+        {strings.clickToDownload}
+      </DownloadFileButton>
     </div>
   );
 }

--- a/packages/sanity-cms/components/SanityTile.tsx
+++ b/packages/sanity-cms/components/SanityTile.tsx
@@ -3,8 +3,15 @@ import { SanityImage } from './SanityImage';
 import type { SessionSanityClient } from '../lib/client';
 import { cn } from '@session/ui/lib/utils';
 import { TILES_VARIANT } from '../schemas/fields/component/tiles';
+import { cleanSanityString } from '../lib/string';
+import { resolveAmbiguousLink } from '../schemas/fields/basic/links';
+import { Button } from '@session/ui/ui/button';
+import Link from 'next/link';
+import { LinkOutIcon } from '@session/ui/icons/LinkOutIcon';
+import { KeyIcon } from '@session/ui/icons/KeyIcon';
+import { safeTry } from '@session/util-js/try';
 
-export function SanityTile({
+export async function SanityTile({
   value,
   variant,
   client,
@@ -78,7 +85,49 @@ export function SanityTileTextOnTopOfImage({
   );
 }
 
-export function SanityTileTextUnderImage({
+type BadgeIconType = 'linkOut' | 'key';
+
+const isValidBadgeIcon = (val: string): val is BadgeIconType => {
+  const cleanVal = cleanSanityString(val);
+  return cleanVal === 'linkOut' || cleanVal === 'key';
+};
+
+type BadgeProps = {
+  client: SessionSanityClient;
+  icon: string;
+  link: unknown;
+};
+
+async function Badge({ client, link, icon }: BadgeProps) {
+  // @ts-expect-error -- These types are pretty rough, this is fine
+  const [err, res] = await safeTry(resolveAmbiguousLink(client, link));
+
+  if (err) {
+    console.error(err);
+    return null;
+  }
+
+  if (!res?.href) {
+    console.warn(`A Badge was set without a href! ${link}`)
+    return null;
+  }
+
+  return (
+    <Link href={res.href} title={res.label}>
+      <Button
+        data-testid="button:tile-badge"
+        size="icon"
+        variant="ghost"
+        className="h-5 w-5"
+        aria-label={res.label}
+      >
+        {icon === 'key' ? <KeyIcon className="h-3 w-3" /> : <LinkOutIcon className="h-3 w-3" />}
+      </Button>
+    </Link>
+  );
+}
+
+export async function SanityTileTextUnderImage({
   value,
   client,
 }: {
@@ -89,6 +138,7 @@ export function SanityTileTextUnderImage({
     console.warn('Missing image for tile');
     return null;
   }
+
   return (
     <div className="flex h-max w-full flex-col gap-1">
       <SanityImage
@@ -98,7 +148,12 @@ export function SanityTileTextUnderImage({
         isInline={false}
         className="h-60 w-full rounded-2xl border border-gray-200 shadow-md"
       />
-      <span className="ms-2 text-sm md:text-base">{value.title}</span>
+      <span className="ms-2 text-sm md:text-base">
+        {value.title}
+        {value.badge && value.badgeIcon && isValidBadgeIcon(value.badgeIcon) ? (
+          <Badge client={client} icon={value.badgeIcon} link={value.badge} />
+        ) : null}
+      </span>
       <span className="ms-2 text-xs font-light md:text-sm">{value.description ?? ' '}</span>
     </div>
   );

--- a/packages/sanity-cms/schemas/fields/component/tile.ts
+++ b/packages/sanity-cms/schemas/fields/component/tile.ts
@@ -1,6 +1,7 @@
 import { defineField } from 'sanity';
 import type { SchemaFieldsType } from '../../types';
 import { imageFieldWithOutAltText } from '../basic/image';
+import { internalLinkFieldDefinition } from '../basic/links';
 
 export const tileFields = [
   defineField({
@@ -15,6 +16,21 @@ export const tileFields = [
     title: 'Description',
     type: 'string',
     description: 'The text content of the tile',
+  }),
+  defineField({
+    ...internalLinkFieldDefinition,
+    name: 'badge',
+    title: 'Badge Link',
+    type: 'reference',
+    to: [{ type: 'page' }, { type: 'post' }, { type: 'special' }, { type: 'cmsFile' }],
+  }),
+  defineField({
+    name: 'badgeIcon',
+    title: 'Badge Icon',
+    type: 'string',
+    options: {
+      list: ['linkOut', 'key'],
+    },
   }),
   imageFieldWithOutAltText,
 ];

--- a/packages/ui/icons/KeyIcon.tsx
+++ b/packages/ui/icons/KeyIcon.tsx
@@ -1,0 +1,1 @@
+export { KeyRound as KeyIcon } from 'lucide-react';


### PR DESCRIPTION
- Added support for `.asc` files in the `FileDownload` component by introducing a new `SanityAsc` component for rendering `.asc` files and updating logic to differentiate between file types (`.pdf` and `.asc`). 
- Introduced badge functionality in `SanityTile` components, allowing tiles to display a badge icon (`linkOut` or `key`) with a link. This includes a new `Badge` subcomponent and validation for badge icons. 